### PR TITLE
fix: list moments error handling

### DIFF
--- a/api/record.go
+++ b/api/record.go
@@ -233,8 +233,7 @@ func (c *recordClient) ListAllEvents(ctx context.Context, recordName *name.Recor
 		})
 		res, err := c.recordServiceClient.ListRecordEvents(ctx, req)
 		if err != nil {
-			// return empty list if error
-			return []*openv1alpha1resource.Event{}, fmt.Errorf("failed to list events at skip %d: %w", skip, err)
+			return nil, fmt.Errorf("failed to list events at skip %d: %w", skip, err)
 		}
 		if len(res.Msg.Events) == 0 {
 			break
@@ -249,8 +248,7 @@ func (c *recordClient) ListAllEvents(ctx context.Context, recordName *name.Recor
 func (c *recordClient) ListAllMoments(ctx context.Context, recordName *name.Record) ([]*Moment, error) {
 	events, err := c.ListAllEvents(ctx, recordName)
 	if err != nil {
-		// ignore the error and return empty list
-		return []*Moment{}, nil
+		return nil, err
 	}
 
 	return lo.Map(events, func(event *openv1alpha1resource.Event, _ int) *Moment {

--- a/api/record.go
+++ b/api/record.go
@@ -233,7 +233,8 @@ func (c *recordClient) ListAllEvents(ctx context.Context, recordName *name.Recor
 		})
 		res, err := c.recordServiceClient.ListRecordEvents(ctx, req)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list events at skip %d: %w", skip, err)
+			// return empty list if error
+			return []*openv1alpha1resource.Event{}, fmt.Errorf("failed to list events at skip %d: %w", skip, err)
 		}
 		if len(res.Msg.Events) == 0 {
 			break
@@ -248,7 +249,8 @@ func (c *recordClient) ListAllEvents(ctx context.Context, recordName *name.Recor
 func (c *recordClient) ListAllMoments(ctx context.Context, recordName *name.Record) ([]*Moment, error) {
 	events, err := c.ListAllEvents(ctx, recordName)
 	if err != nil {
-		return nil, err
+		// ignore the error and return empty list
+		return []*Moment{}, nil
 	}
 
 	return lo.Map(events, func(event *openv1alpha1resource.Event, _ int) *Moment {

--- a/pkg/cmd/record/download.go
+++ b/pkg/cmd/record/download.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/api"
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/fs"
 	"github.com/coscene-io/cocli/internal/name"
@@ -131,6 +132,8 @@ func NewDownloadCommand(cfgPath *string) *cobra.Command {
 			if includeMoments {
 				moments, err := pm.RecordCli().ListAllMoments(cmd.Context(), recordName)
 				if err != nil {
+					// ignore the error and return empty list
+					moments = []*api.Moment{}
 					log.Errorf("unable to list moments: %v", err)
 				}
 				totalFiles++

--- a/pkg/cmd/record/download.go
+++ b/pkg/cmd/record/download.go
@@ -129,16 +129,15 @@ func NewDownloadCommand(cfgPath *string) *cobra.Command {
 			}
 
 			if includeMoments {
-				if moments, err := pm.RecordCli().ListAllMoments(cmd.Context(), recordName); err != nil {
+				moments, err := pm.RecordCli().ListAllMoments(cmd.Context(), recordName)
+				if err != nil {
 					log.Errorf("unable to list moments: %v", err)
+				}
+				totalFiles++
+				if err = cmd_utils.SaveMomentsJson(moments, dstDir); err != nil {
+					log.Fatalf("unable to save moments: %v", err)
 				} else {
-					totalFiles++
-					err := cmd_utils.SaveMomentsJson(moments, dstDir)
-					if err != nil {
-						log.Fatalf("unable to save moments: %v", err)
-					} else {
-						successCount++
-					}
+					successCount++
 				}
 			}
 

--- a/pkg/cmd/record/list_moments.go
+++ b/pkg/cmd/record/list_moments.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
 	"connectrpc.com/connect"
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/printer"
@@ -62,6 +63,7 @@ func NewListMomentsCommand(cfgPath *string) *cobra.Command {
 			moments, err := pm.RecordCli().ListAllEvents(cmd.Context(), recordName)
 			if err != nil {
 				// ignore the error and return empty list
+				moments = []*openv1alpha1resource.Event{}
 				log.Errorf("unable to list moments: %v", err)
 			}
 

--- a/pkg/cmd/record/list_moments.go
+++ b/pkg/cmd/record/list_moments.go
@@ -61,7 +61,8 @@ func NewListMomentsCommand(cfgPath *string) *cobra.Command {
 			// List moments in record.
 			moments, err := pm.RecordCli().ListAllEvents(cmd.Context(), recordName)
 			if err != nil {
-				log.Fatalf("unable to list moments: %v", err)
+				// ignore the error and return empty list
+				log.Errorf("unable to list moments: %v", err)
 			}
 
 			if err = printer.Printer(outputFormat, &printer.Options{TableOpts: &table.PrintOpts{


### PR DESCRIPTION
Fix error handling when listing moments or downloading record files with moments.

- Sync behavior with front-end to ignore the error when moments are not correctly listed.
  - return empty `moments.json` even if an error is present.