### PR TITLE
feat: add no-tty flag when uploading

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	go.etcd.io/bbolt v1.3.11
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/net v0.29.0
+	golang.org/x/term v0.24.0
 	google.golang.org/genproto v0.0.0-20241021214115-324edc3d5d38
 	google.golang.org/protobuf v1.36.6
 )
@@ -66,7 +67,6 @@ require (
 	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
-	golang.org/x/term v0.24.0 // indirect
 	golang.org/x/text v0.18.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241021214115-324edc3d5d38 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/pkg/cmd/record/create.go
+++ b/pkg/cmd/record/create.go
@@ -107,6 +107,7 @@ func NewCreateCommand(cfgPath *string) *cobra.Command {
 	cmd.Flags().IntVarP(&multiOpts.Threads, "parallel", "P", 4, "number of uploads (could be part) in parallel")
 	cmd.Flags().StringVarP(&multiOpts.PartSize, "part-size", "s", "128Mib", "each part size")
 	cmd.Flags().DurationVar(&timeout, "response-timeout", 5*time.Minute, "server response time out")
+	cmd.Flags().BoolVar(&multiOpts.NoTTY, "no-tty", false, "disable interactive mode for headless environments")
 
 	return cmd
 }

--- a/pkg/cmd/record/create.go
+++ b/pkg/cmd/record/create.go
@@ -108,6 +108,9 @@ func NewCreateCommand(cfgPath *string) *cobra.Command {
 	cmd.Flags().StringVarP(&multiOpts.PartSize, "part-size", "s", "128Mib", "each part size")
 	cmd.Flags().DurationVar(&timeout, "response-timeout", 5*time.Minute, "server response time out")
 	cmd.Flags().BoolVar(&multiOpts.NoTTY, "no-tty", false, "disable interactive mode for headless environments")
+	cmd.Flags().BoolVar(&multiOpts.TTY, "tty", false, "force interactive mode even in headless environments")
+
+	cmd.MarkFlagsMutuallyExclusive("no-tty", "tty")
 
 	return cmd
 }

--- a/pkg/cmd/record/upload.go
+++ b/pkg/cmd/record/upload.go
@@ -93,6 +93,7 @@ func NewUploadCommand(cfgPath *string) *cobra.Command {
 	cmd.Flags().IntVarP(&uploadManagerOpts.Threads, "parallel", "P", 4, "number of uploads (could be part) in parallel")
 	cmd.Flags().StringVarP(&uploadManagerOpts.PartSize, "part-size", "s", "128Mib", "each part size")
 	cmd.Flags().DurationVar(&timeout, "response-timeout", 5*time.Minute, "server response time out")
+	cmd.Flags().BoolVar(&uploadManagerOpts.NoTTY, "no-tty", false, "disable interactive mode for headless environments")
 
 	return cmd
 }

--- a/pkg/cmd/record/upload.go
+++ b/pkg/cmd/record/upload.go
@@ -94,6 +94,9 @@ func NewUploadCommand(cfgPath *string) *cobra.Command {
 	cmd.Flags().StringVarP(&uploadManagerOpts.PartSize, "part-size", "s", "128Mib", "each part size")
 	cmd.Flags().DurationVar(&timeout, "response-timeout", 5*time.Minute, "server response time out")
 	cmd.Flags().BoolVar(&uploadManagerOpts.NoTTY, "no-tty", false, "disable interactive mode for headless environments")
+	cmd.Flags().BoolVar(&uploadManagerOpts.TTY, "tty", false, "force interactive mode even in headless environments")
+
+	cmd.MarkFlagsMutuallyExclusive("no-tty", "tty")
 
 	return cmd
 }

--- a/pkg/cmd_utils/upload_utils/opt.go
+++ b/pkg/cmd_utils/upload_utils/opt.go
@@ -22,6 +22,7 @@ type UploadManagerOpts struct {
 	Threads        int
 	PartSize       string
 	partSizeUint64 uint64
+	NoTTY          bool
 }
 
 func (opt *UploadManagerOpts) Valid() error {

--- a/pkg/cmd_utils/upload_utils/opt.go
+++ b/pkg/cmd_utils/upload_utils/opt.go
@@ -7,6 +7,7 @@ import (
 	"github.com/coscene-io/cocli/api"
 	"github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
+	"golang.org/x/term"
 )
 
 type ApiOpts struct {
@@ -22,7 +23,8 @@ type UploadManagerOpts struct {
 	Threads        int
 	PartSize       string
 	partSizeUint64 uint64
-	NoTTY          bool
+	NoTTY          bool // Force non-interactive mode
+	TTY            bool // Force interactive mode
 }
 
 func (opt *UploadManagerOpts) Valid() error {
@@ -39,6 +41,40 @@ func (opt *UploadManagerOpts) partSize() (uint64, error) {
 		return defaultPartSize, nil
 	}
 	return humanize.ParseBytes(opt.PartSize)
+}
+
+// IsHeadlessEnvironment detects if we're running in a CI/headless environment
+func IsHeadlessEnvironment() bool {
+	// Check if stdin or stdout is not a terminal
+	if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stdout.Fd())) {
+		return true
+	}
+
+	// Check for common CI environment variables
+	if os.Getenv("CI") == "true" {
+		return true
+	}
+
+	// Check for dumb terminal
+	if os.Getenv("TERM") == "dumb" {
+		return true
+	}
+
+	return false
+}
+
+// ShouldUseInteractiveMode determines if interactive mode should be used
+func (opt *UploadManagerOpts) ShouldUseInteractiveMode() bool {
+	// Explicit flags take precedence
+	if opt.NoTTY {
+		return false
+	}
+	if opt.TTY {
+		return true
+	}
+
+	// Auto-detect based on environment
+	return !IsHeadlessEnvironment()
 }
 
 type FileOpts struct {


### PR DESCRIPTION
Add no-tty flag for cocli when using `cocli record upload` to work in a headless environment.