### PR TITLE
feat: add record describe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	golang.org/x/net v0.29.0
 	google.golang.org/genproto v0.0.0-20241021214115-324edc3d5d38
 	google.golang.org/protobuf v1.36.6
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -70,5 +71,4 @@ require (
 	golang.org/x/text v0.18.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241021214115-324edc3d5d38 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/cmd/record/create.go
+++ b/pkg/cmd/record/create.go
@@ -66,14 +66,13 @@ func NewCreateCommand(cfgPath *string) *cobra.Command {
 				log.Fatalf("Failed to create record: %v", err)
 			}
 
-			fmt.Printf("Record created: %v\n", res.Name)
 			recordName, _ := name.NewRecord(res.Name)
-			recordUrl, err := pm.GetRecordUrl(recordName)
-			if err != nil {
-				log.Errorf("unable to get record url: %v", err)
-			} else {
-				fmt.Println("The record url is:", recordUrl)
-			}
+
+			// Display detailed record information
+			fmt.Println("\nRecord created successfully!")
+			fmt.Println("-------------------------------------------------------------")
+			DisplayRecord(res, pm)
+			fmt.Println("-------------------------------------------------------------")
 
 			if thumbnail != "" {
 				// Upload thumbnail.

--- a/pkg/cmd/record/describe.go
+++ b/pkg/cmd/record/describe.go
@@ -113,15 +113,15 @@ func outputTable(record interface{}) {
 		labelNames := []string{}
 		for _, label := range labels {
 			if labelMap, ok := label.(map[string]interface{}); ok {
-				labelNames = append(labelNames, getString(labelMap, "displayName"))
+				labelNames = append(labelNames, getString(labelMap, "display_name"))
 			}
 		}
 		fmt.Printf("%-20s %s\n", "Labels:", strings.Join(labelNames, ", "))
 	}
 
 	// Times
-	fmt.Printf("%-20s %s\n", "Create Time:", formatTime(getString(data, "createTime")))
-	fmt.Printf("%-20s %s\n", "Update Time:", formatTime(getString(data, "updateTime")))
+	fmt.Printf("%-20s %s\n", "Create Time:", formatTimeFromMap(getMap(data, "create_time")))
+	fmt.Printf("%-20s %s\n", "Update Time:", formatTimeFromMap(getMap(data, "update_time")))
 
 	// Duration
 	if duration := getString(data, "duration"); duration != "" {
@@ -129,10 +129,10 @@ func outputTable(record interface{}) {
 	}
 
 	// Archived status
-	fmt.Printf("%-20s %v\n", "Archived:", getBool(data, "isArchived"))
+	fmt.Printf("%-20s %v\n", "Archived:", getBool(data, "is_archived"))
 
 	// Total size
-	if totalSize := getFloat64(data, "totalSize"); totalSize > 0 {
+	if totalSize := getFloat64(data, "total_size"); totalSize > 0 {
 		fmt.Printf("%-20s %.2f MB\n", "Total Size:", totalSize/1024/1024)
 	}
 }
@@ -220,5 +220,21 @@ func formatTime(timeStr string) string {
 		}
 	}
 
+	return t.In(time.Local).Format(time.RFC3339)
+}
+
+func formatTimeFromMap(timeMap map[string]interface{}) string {
+	if timeMap == nil {
+		return ""
+	}
+
+	seconds := getFloat64(timeMap, "seconds")
+	nanos := getFloat64(timeMap, "nanos")
+
+	if seconds == 0 {
+		return ""
+	}
+
+	t := time.Unix(int64(seconds), int64(nanos))
 	return t.In(time.Local).Format(time.RFC3339)
 }

--- a/pkg/cmd/record/describe.go
+++ b/pkg/cmd/record/describe.go
@@ -262,24 +262,6 @@ func getFloat64(m map[string]interface{}, key string) float64 {
 	return 0
 }
 
-func formatTime(timeStr string) string {
-	if timeStr == "" {
-		return ""
-	}
-
-	// Try to parse the time string
-	t, err := time.Parse(time.RFC3339Nano, timeStr)
-	if err != nil {
-		// Try other formats
-		t, err = time.Parse(time.RFC3339, timeStr)
-		if err != nil {
-			return timeStr // Return as-is if can't parse
-		}
-	}
-
-	return t.In(time.Local).Format(time.RFC3339)
-}
-
 func formatTimeFromMap(timeMap map[string]interface{}) string {
 	if timeMap == nil {
 		return ""

--- a/pkg/cmd/record/describe.go
+++ b/pkg/cmd/record/describe.go
@@ -1,0 +1,224 @@
+// Copyright 2024 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/name"
+	"github.com/coscene-io/cocli/internal/utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+func NewDescribeCommand(cfgPath *string) *cobra.Command {
+	var (
+		projectSlug  = ""
+		outputFormat = ""
+	)
+
+	cmd := &cobra.Command{
+		Use:                   "describe <record-resource-name/id> [-p <working-project-slug>] [-o <output-format>]",
+		Short:                 "Describe record metadata.",
+		Args:                  cobra.ExactArgs(1),
+		DisableFlagsInUseLine: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			// Get current profile.
+			pm, _ := config.Provide(*cfgPath).GetProfileManager()
+			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
+			if err != nil {
+				log.Fatalf("unable to get project name: %v", err)
+			}
+
+			// Handle args and flags.
+			recordName, err := pm.RecordCli().RecordId2Name(context.TODO(), args[0], proj)
+			if utils.IsConnectErrorWithCode(err, connect.CodeNotFound) {
+				fmt.Printf("failed to find record: %s in project: %s\n", args[0], proj)
+				return
+			} else if err != nil {
+				log.Fatalf("unable to get record name from %s: %v", args[0], err)
+			}
+
+			// Get record details.
+			record, err := pm.RecordCli().Get(context.TODO(), recordName)
+			if err != nil {
+				log.Fatalf("unable to get record: %v", err)
+			}
+
+			// Output based on format.
+			switch outputFormat {
+			case "json":
+				if err := outputJSON(record); err != nil {
+					log.Fatalf("unable to output JSON: %v", err)
+				}
+			case "yaml":
+				if err := outputYAML(record); err != nil {
+					log.Fatalf("unable to output YAML: %v", err)
+				}
+			default:
+				outputTable(record)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&projectSlug, "project", "p", "", "the slug of the working project")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "output format (table|json|yaml)")
+
+	return cmd
+}
+
+func outputTable(record interface{}) {
+	// Convert record to a map for easier handling
+	data, err := convertToMap(record)
+	if err != nil {
+		log.Fatalf("unable to convert record: %v", err)
+	}
+
+	// Extract record name parts
+	recordName, _ := name.NewRecord(getString(data, "name"))
+
+	// Print formatted output
+	fmt.Printf("%-20s %s\n", "ID:", recordName.RecordID)
+	fmt.Printf("%-20s %s\n", "Name:", getString(data, "name"))
+	fmt.Printf("%-20s %s\n", "Title:", getString(data, "title"))
+	fmt.Printf("%-20s %s\n", "Description:", getString(data, "description"))
+
+	// Device
+	if device := getMap(data, "device"); device != nil {
+		fmt.Printf("%-20s %s\n", "Device:", getString(device, "name"))
+	}
+
+	// Labels
+	if labels := getSlice(data, "labels"); len(labels) > 0 {
+		labelNames := []string{}
+		for _, label := range labels {
+			if labelMap, ok := label.(map[string]interface{}); ok {
+				labelNames = append(labelNames, getString(labelMap, "displayName"))
+			}
+		}
+		fmt.Printf("%-20s %s\n", "Labels:", strings.Join(labelNames, ", "))
+	}
+
+	// Times
+	fmt.Printf("%-20s %s\n", "Create Time:", formatTime(getString(data, "createTime")))
+	fmt.Printf("%-20s %s\n", "Update Time:", formatTime(getString(data, "updateTime")))
+
+	// Duration
+	if duration := getString(data, "duration"); duration != "" {
+		fmt.Printf("%-20s %s\n", "Duration:", duration)
+	}
+
+	// Archived status
+	fmt.Printf("%-20s %v\n", "Archived:", getBool(data, "isArchived"))
+
+	// Total size
+	if totalSize := getFloat64(data, "totalSize"); totalSize > 0 {
+		fmt.Printf("%-20s %.2f MB\n", "Total Size:", totalSize/1024/1024)
+	}
+}
+
+func outputJSON(record interface{}) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(record)
+}
+
+func outputYAML(record interface{}) error {
+	encoder := yaml.NewEncoder(os.Stdout)
+	encoder.SetIndent(2)
+	return encoder.Encode(record)
+}
+
+func convertToMap(v interface{}) (map[string]interface{}, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	return result, err
+}
+
+func getString(m map[string]interface{}, key string) string {
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func getMap(m map[string]interface{}, key string) map[string]interface{} {
+	if v, ok := m[key]; ok {
+		if mapVal, ok := v.(map[string]interface{}); ok {
+			return mapVal
+		}
+	}
+	return nil
+}
+
+func getSlice(m map[string]interface{}, key string) []interface{} {
+	if v, ok := m[key]; ok {
+		if slice, ok := v.([]interface{}); ok {
+			return slice
+		}
+	}
+	return nil
+}
+
+func getBool(m map[string]interface{}, key string) bool {
+	if v, ok := m[key]; ok {
+		if b, ok := v.(bool); ok {
+			return b
+		}
+	}
+	return false
+}
+
+func getFloat64(m map[string]interface{}, key string) float64 {
+	if v, ok := m[key]; ok {
+		if f, ok := v.(float64); ok {
+			return f
+		}
+	}
+	return 0
+}
+
+func formatTime(timeStr string) string {
+	if timeStr == "" {
+		return ""
+	}
+
+	// Try to parse the time string
+	t, err := time.Parse(time.RFC3339Nano, timeStr)
+	if err != nil {
+		// Try other formats
+		t, err = time.Parse(time.RFC3339, timeStr)
+		if err != nil {
+			return timeStr // Return as-is if can't parse
+		}
+	}
+
+	return t.In(time.Local).Format(time.RFC3339)
+}

--- a/pkg/cmd/record/root.go
+++ b/pkg/cmd/record/root.go
@@ -28,6 +28,7 @@ func NewRootCommand(cfgPath *string) *cobra.Command {
 	cmd.AddCommand(NewCreateCommand(cfgPath))
 	cmd.AddCommand(NewCreateMomentCmd(cfgPath))
 	cmd.AddCommand(NewDeleteCommand(cfgPath))
+	cmd.AddCommand(NewDescribeCommand(cfgPath))
 	cmd.AddCommand(NewDownloadCommand(cfgPath))
 	cmd.AddCommand(NewListCommand(cfgPath))
 	cmd.AddCommand(NewListFilesCommand(cfgPath))


### PR DESCRIPTION
- Add `cocli record describe` command to output record metadata in `table/yaml/json` format.
- Add `describe` info when using `cocli record create` command.
- Add `url` to metadata