### PR TITLE
feat: add pagination for record list and support filter by labels and keywords

### DIFF
--- a/api/record.go
+++ b/api/record.go
@@ -54,7 +54,7 @@ type RecordInterface interface {
 	// Update updates a record.
 	Update(ctx context.Context, recordName *name.Record, title string, description string, labels []*openv1alpha1resource.Label, fieldMask []string) error
 
-	//ListAllEvents lists all events in a record.
+	// ListAllEvents lists all events in a record.
 	ListAllEvents(ctx context.Context, recordName *name.Record) ([]*openv1alpha1resource.Event, error)
 
 	// ListAllMoments lists all moments in a record.
@@ -62,6 +62,9 @@ type RecordInterface interface {
 
 	// ListAll lists all records in a project.
 	ListAll(ctx context.Context, options *ListRecordsOptions) ([]*openv1alpha1resource.Record, error)
+
+	// ListWithPagination lists records in a project with pagination support.
+	ListWithPagination(ctx context.Context, options *ListRecordsOptions, pageSize int, skip int) ([]*openv1alpha1resource.Record, error)
 
 	// GenerateRecordThumbnailUploadUrl generates a pre-signed URL for uploading a record thumbnail.
 	GenerateRecordThumbnailUploadUrl(ctx context.Context, recordName *name.Record) (string, error)
@@ -73,6 +76,7 @@ type RecordInterface interface {
 type ListRecordsOptions struct {
 	Project        *name.Project
 	Titles         []string
+	Labels         []string
 	IncludeArchive bool
 }
 
@@ -80,6 +84,7 @@ type recordClient struct {
 	recordServiceClient openv1alpha1connect.RecordServiceClient
 	fileServiceClient   openv1alpha1connect.FileServiceClient
 	userServiceClient   openv1alpha1connect.UserServiceClient
+	labelServiceClient  openv1alpha1connect.LabelServiceClient
 }
 
 type Moment struct {
@@ -91,11 +96,12 @@ type Moment struct {
 	CustomFieldValues []map[string]any  `json:"customFieldValues"`
 }
 
-func NewRecordClient(recordServiceClient openv1alpha1connect.RecordServiceClient, fileServiceClient openv1alpha1connect.FileServiceClient, userServiceClient openv1alpha1connect.UserServiceClient) RecordInterface {
+func NewRecordClient(recordServiceClient openv1alpha1connect.RecordServiceClient, fileServiceClient openv1alpha1connect.FileServiceClient, userServiceClient openv1alpha1connect.UserServiceClient, labelServiceClient openv1alpha1connect.LabelServiceClient) RecordInterface {
 	return &recordClient{
 		recordServiceClient: recordServiceClient,
 		fileServiceClient:   fileServiceClient,
 		userServiceClient:   userServiceClient,
+		labelServiceClient:  labelServiceClient,
 	}
 }
 
@@ -345,6 +351,27 @@ func (c *recordClient) ListAll(ctx context.Context, options *ListRecordsOptions)
 	return ret, nil
 }
 
+func (c *recordClient) ListWithPagination(ctx context.Context, options *ListRecordsOptions, pageSize int, skip int) ([]*openv1alpha1resource.Record, error) {
+	if options.Project.ProjectID == "" {
+		return nil, errors.Errorf("invalid project: %s", options.Project)
+	}
+
+	filter := c.filter(options)
+
+	req := connect.NewRequest(&openv1alpha1service.ListRecordsRequest{
+		Parent:   options.Project.String(),
+		PageSize: int32(pageSize),
+		Skip:     int32(skip),
+		Filter:   filter,
+	})
+	res, err := c.recordServiceClient.ListRecords(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list records: %w", err)
+	}
+
+	return res.Msg.Records, nil
+}
+
 func (c *recordClient) filter(opts *ListRecordsOptions) string {
 	var filters []string
 	if !opts.IncludeArchive {
@@ -355,6 +382,16 @@ func (c *recordClient) filter(opts *ListRecordsOptions) string {
 			lo.Map(opts.Titles, func(title string, _ int) string { return fmt.Sprintf(`title:"%s"`, title) }),
 			` OR `,
 		)+")")
+	}
+	if len(opts.Labels) > 0 {
+		// Transform label display names to label IDs, following backend implementation
+		labelFilters, err := c.transformLabels(context.TODO(), opts.Project.String(), opts.Labels)
+		if err != nil {
+			// If label lookup fails, log warning but don't fail the entire request
+			fmt.Printf("Warning: failed to lookup labels: %v\n", err)
+		} else if len(labelFilters) > 0 {
+			filters = append(filters, "("+strings.Join(labelFilters, ` OR `)+")")
+		}
 	}
 	return strings.Join(filters, " AND ")
 }
@@ -386,4 +423,56 @@ func (c *recordClient) RecordId2Name(ctx context.Context, recordIdOrName string,
 	}
 
 	return recordName, nil
+}
+
+// transformLabels converts label display names to label IDs for filtering
+// Based on the implementation in /x/record/client.go
+func (c *recordClient) transformLabels(ctx context.Context, parent string, labelNames []string) ([]string, error) {
+	if len(labelNames) == 0 {
+		return nil, nil
+	}
+
+	// Create a map to track label display name to ID mapping
+	labelNameIdMap := make(map[string]string)
+	for _, labelName := range labelNames {
+		labelNameIdMap[labelName] = ""
+	}
+
+	// List labels from platform server using batch lookup
+	req := connect.NewRequest(&openv1alpha1service.ListLabelsRequest{
+		Parent:   parent,
+		Filter:   fmt.Sprintf("display_name=[%s]", strings.Join(labelNames, `,`)),
+		PageSize: constants.MaxPageSize,
+	})
+	labelResp, err := c.labelServiceClient.ListLabels(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list labels: %w", err)
+	}
+
+	// Extract label IDs from the response
+	for _, label := range labelResp.Msg.Labels {
+		labelNameArr := strings.Split(label.Name, `/`)
+		labelId := labelNameArr[len(labelNameArr)-1]
+		labelNameIdMap[label.DisplayName] = labelId
+	}
+
+	// Check for missing labels
+	var missedLabelNames []string
+	for labelName, labelId := range labelNameIdMap {
+		if labelId == "" {
+			missedLabelNames = append(missedLabelNames, labelName)
+		}
+	}
+	if len(missedLabelNames) > 0 {
+		return nil, fmt.Errorf("labels not found: %v", strings.Join(missedLabelNames, ","))
+	}
+
+	// Construct label filters using label IDs
+	var ret []string
+	for _, labelName := range labelNames {
+		labelId := labelNameIdMap[labelName]
+		ret = append(ret, fmt.Sprintf("labels=[%s]", labelId))
+	}
+
+	return ret, nil
 }

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -235,7 +235,7 @@ func (p *Profile) initCli() {
 
 		p.orgcli = api.NewOrganizationClient(organizationServiceClient)
 		p.projcli = api.NewProjectClient(projectServiceClient)
-		p.rcdcli = api.NewRecordClient(recordServiceClient, fileServiceClient, userServiceClient)
+		p.rcdcli = api.NewRecordClient(recordServiceClient, fileServiceClient, userServiceClient, labelServiceClient)
 		p.lblcli = api.NewLabelClient(labelServiceClient)
 		p.usercli = api.NewUserClient(userServiceClient)
 		p.filecli = api.NewFileClient(fileServiceClient)

--- a/pkg/cmd/record/list.go
+++ b/pkg/cmd/record/list.go
@@ -53,6 +53,9 @@ func NewListCommand(cfgPath *string) *cobra.Command {
 			if pageSize > 0 && (pageSize < 10 || pageSize > 100) {
 				log.Fatalf("--page-size must be between 10 and 100")
 			}
+			if page < 1 {
+				log.Fatalf("--page must be >= 1")
+			}
 
 			// Get current profile.
 			pm, _ := config.Provide(*cfgPath).GetProfileManager()
@@ -128,7 +131,7 @@ func NewListCommand(cfgPath *string) *cobra.Command {
 	cmd.Flags().StringVarP(&projectSlug, "project", "p", "", "the slug of the working project")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 	cmd.Flags().BoolVar(&includeArchive, "include-archive", false, "include archived records")
-	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "output format (table|json)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "output format (table|json|yaml)")
 	cmd.Flags().IntVar(&pageSize, "page-size", 0, "number of records per page (10-100)")
 	cmd.Flags().IntVar(&page, "page", 1, "page number (1-based, requires --page-size)")
 	cmd.Flags().BoolVar(&all, "all", false, "list all records (overrides default page size)")

--- a/pkg/cmd/record/list.go
+++ b/pkg/cmd/record/list.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os"
 
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
 	"github.com/coscene-io/cocli/api"
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/printer"
@@ -33,14 +34,26 @@ func NewListCommand(cfgPath *string) *cobra.Command {
 		verbose        = false
 		includeArchive = false
 		outputFormat   = ""
+		pageSize       = 0
+		page           = 0
+		labels         []string
+		titles         []string
 	)
 
 	cmd := &cobra.Command{
-		Use:                   "list [-v] [-p <working-project-slug>] [--include-archive]",
+		Use:                   "list [-v] [-p <working-project-slug>] [--include-archive] [--page-size <size>] [--page <number>] [--labels <label1,label2>] [--keywords <keyword1,keyword2>]",
 		Short:                 "List records in the project.",
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
+			// Validate pagination flags
+			if page > 1 && pageSize <= 0 {
+				log.Fatalf("--page requires --page-size to be specified")
+			}
+			if pageSize > 0 && (pageSize < 10 || pageSize > 100) {
+				log.Fatalf("--page-size must be between 10 and 100")
+			}
+
 			// Get current profile.
 			pm, _ := config.Provide(*cfgPath).GetProfileManager()
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
@@ -48,13 +61,34 @@ func NewListCommand(cfgPath *string) *cobra.Command {
 				log.Fatalf("unable to get project name: %v", err)
 			}
 
-			// List records in project.
-			records, err := pm.RecordCli().ListAll(context.TODO(), &api.ListRecordsOptions{
+			var records []*openv1alpha1resource.Record
+
+			// Prepare list options with filters
+			listOptions := &api.ListRecordsOptions{
 				Project:        proj,
 				IncludeArchive: includeArchive,
-			})
-			if err != nil {
-				log.Fatalf("unable to list records: %v", err)
+				Labels:         labels,
+				Titles:         titles,
+			}
+
+			// Use pagination if page size is specified
+			if pageSize > 0 {
+				// Calculate skip based on page number (page is 1-based)
+				skip := 0
+				if page > 1 {
+					skip = (page - 1) * pageSize
+				}
+
+				records, err = pm.RecordCli().ListWithPagination(context.TODO(), listOptions, pageSize, skip)
+				if err != nil {
+					log.Fatalf("unable to list records: %v", err)
+				}
+			} else {
+				// List all records (existing behavior)
+				records, err = pm.RecordCli().ListAll(context.TODO(), listOptions)
+				if err != nil {
+					log.Fatalf("unable to list records: %v", err)
+				}
 			}
 
 			// Print listed records.
@@ -76,6 +110,10 @@ func NewListCommand(cfgPath *string) *cobra.Command {
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 	cmd.Flags().BoolVar(&includeArchive, "include-archive", false, "include archived records")
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "output format (table|json)")
+	cmd.Flags().IntVar(&pageSize, "page-size", 0, "number of records per page (10-100, 0 for all records)")
+	cmd.Flags().IntVar(&page, "page", 1, "page number (1-based, requires --page-size)")
+	cmd.Flags().StringSliceVar(&labels, "labels", []string{}, "filter by labels (comma-separated)")
+	cmd.Flags().StringSliceVar(&titles, "keywords", []string{}, "filter by keywords in titles (comma-separated)")
 
 	return cmd
 }


### PR DESCRIPTION
added new options for `cocli record list`.
- `--page-size`: should be between 10 and 100.
- `--page`: default to 1
- `--labels`: support comma-separated labels.
- `--keywords`: filter by title.