### PR TITLE
fix: copy-files api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/coscene-io/cocli
 go 1.23.2
 
 require (
-	buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.18.1-20250122060750-4df03e5a2d69.1
-	buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.6-20250528054851-ffad06bcc38a.1
+	buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.18.1-20250716032118-54ed4c71486d.1
+	buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.6-20250716032118-54ed4c71486d.1
 	connectrpc.com/connect v1.18.1
 	dario.cat/mergo v1.0.0
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20240508200655-46a4cf4ba109.1 h1:YUpUQuvzAJorNtpdTw/JsBe8WbFGztxajwl4XO5ZOIE=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20240508200655-46a4cf4ba109.1/go.mod h1:avRlCjnFzl98VPaeCtJ24RrV/wwHFzB8sWXhj26+n/U=
-buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.18.1-20250122060750-4df03e5a2d69.1 h1:mGvSXgsLSdYTOgLsID9QuQvHZ7rwoOgfHp3VjMJitp4=
-buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.18.1-20250122060750-4df03e5a2d69.1/go.mod h1:4apc1RVJmi3ooSXA7dGMK1z5ijSXgXe005uvxvrZAzk=
-buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.6-20250528054851-ffad06bcc38a.1 h1:3nW0Ifw3Nl92L039tR6TUHZFcPjgNMfpYJqwEDN+HXk=
-buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.6-20250528054851-ffad06bcc38a.1/go.mod h1:89cE9hg+EVUYFLDK76q58op06UHEe34JeX3ASfRfb+w=
+buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.18.1-20250716032118-54ed4c71486d.1 h1:sT5N/9ef1RJfShoOtI2pJECkvGrM9hlJlhyxLtFowq0=
+buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.18.1-20250716032118-54ed4c71486d.1/go.mod h1:VTEOPo5qNU2Gkx8jjuc64FvU7cuyZbTiqFPSpzoOCh0=
+buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.6-20250716032118-54ed4c71486d.1 h1:JFdmWc62T9ofqGEukb4KwJ+ceKG5+N6ANn3FYFqIdVc=
+buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.6-20250716032118-54ed4c71486d.1/go.mod h1:89cE9hg+EVUYFLDK76q58op06UHEe34JeX3ASfRfb+w=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.6-20230414000709-087bc8072ce4.1 h1:QZk9F35A+TnMNgUQBlW+7kjUef086s2jux7f6CI8H+w=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.6-20230414000709-087bc8072ce4.1/go.mod h1:ZSkBzB0CxHcvK9isqj6cCCJ3hDfEPFCpYAN6Mckzr2M=
 connectrpc.com/connect v1.18.1 h1:PAg7CjSAGvscaf6YZKUefjoih5Z/qYkyaTrBW8xvYPw=


### PR DESCRIPTION
Use a relative file path rather than a full file path when sending a `copyFiles` request.