### PR TITLE
fix: update OpenAPI version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.23
+          go-version: 1.25
       - name: Cache
         if: success()
         uses: actions/cache@v3

--- a/api/project.go
+++ b/api/project.go
@@ -21,7 +21,6 @@ import (
 	openv1alpha1connect "buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go/coscene/openapi/dataplatform/v1alpha1/services/servicesconnect"
 	"buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/enums"
 	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
-	"buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/services"
 	openv1alpha1service "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/services"
 	"connectrpc.com/connect"
 	"github.com/coscene-io/cocli/internal/constants"
@@ -64,7 +63,7 @@ type CreateProjectUsingTemplateOptions struct {
 	Slug            string
 	DisplayName     string
 	ProjectTemplate string
-	TemplateScopes  []services.CreateProjectUsingTemplateRequest_TemplateScope
+	TemplateScopes  []openv1alpha1service.CreateProjectUsingTemplateRequest_TemplateScope
 	Visibility      enums.ProjectVisibilityEnum_ProjectVisibility
 	Description     string
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coscene-io/cocli
 
-go 1.23.2
+go 1.25.0
 
 require (
 	buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.18.1-20250915074700-e5499cd30e76.1

--- a/internal/printer/printable/action_run.go
+++ b/internal/printer/printable/action_run.go
@@ -77,7 +77,10 @@ func (p *ActionRun) ToTable(opts *table.PrintOpts) table.Table {
 		{
 			FieldName: "ACTION TITLE",
 			FieldValueFunc: func(a *openv1alpha1resource.ActionRun, opts *table.PrintOpts) string {
-				return a.Action.Spec.Name
+				if a.Action.Spec != nil {
+					return a.Action.Spec.Name
+				}
+				return ""
 			},
 			TrimSize: actionRunActionTitleTrimSize,
 		},

--- a/make/go/dep_golangci_lint.mk
+++ b/make/go/dep_golangci_lint.mk
@@ -9,12 +9,12 @@ $(call _assert_var,CACHE_BIN)
 # Settable
 # https://github.com/golangci/golangci-lint/releases 20220318 checked 20220321
 # Check for new linters and add to .golangci.yml (even if commented out) when upgrading
-GOLANGCI_LINT_VERSION ?= v1.62.0
+GOLANGCI_LINT_VERSION ?= v2.4.0
 
 GOLANGCI_LINT := $(CACHE_VERSIONS)/golangci-lint/$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT):
 	@rm -f $(CACHE_BIN)/golangci-lint
-	GOBIN=$(CACHE_BIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	GOBIN=$(CACHE_BIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	@rm -rf $(dir $(GOLANGCI_LINT))
 	@mkdir -p $(dir $(GOLANGCI_LINT))
 	@touch $(GOLANGCI_LINT)

--- a/make/go/go.mk
+++ b/make/go/go.mk
@@ -17,7 +17,7 @@ GO_TEST_BINS ?=
 # Settable
 GO_GET_PKGS ?=
 # Settable
-GO_MOD_VERSION ?= 1.22
+GO_MOD_VERSION ?= 1.25
 # Settable
 GO_ALL_REPO_PKGS ?=
 # Settable

--- a/pkg/cmd_utils/url_utils.go
+++ b/pkg/cmd_utils/url_utils.go
@@ -155,7 +155,9 @@ func SaveMomentsJson(moments []*api.Moment, dir string) error {
 		log.Fatalf("unable to create moments file %s: %v", momentPath, err)
 		return err
 	}
-	defer momentFile.Close() // Ensure the file is closed
+	defer func() {
+		_ = momentFile.Close()
+	}()
 
 	type Moments struct {
 		Moments []*api.Moment `json:"moments"`


### PR DESCRIPTION
The OpenAPI proto dependency is outdated. The records of an ActionRun are now in a TriggerMatch and should be able to call on multiple records (TODO!).

Additionally, I added a safety wrap to the `Spec.Name` to prevent panic, just in case.