### PR TITLE
fix: set sentry release from cocli version

### DIFF
--- a/cmd/cocli/main.go
+++ b/cmd/cocli/main.go
@@ -28,15 +28,7 @@ import (
 )
 
 func main() {
-	err := sentry.Init(sentry.ClientOptions{
-		Dsn:     "https://b3bcd9e4d101f927b5f1f7ac67d9b115@sentry.coscene.site/23",
-		Release: cocli.GetVersion(),
-		// Set TracesSampleRate to 1.0 to capture 100%
-		// of transactions for tracing.
-		// We recommend adjusting this value in production,
-		TracesSampleRate: 1.0,
-		AttachStacktrace: true,
-	})
+	err := sentry.Init(newSentryClientOptions())
 	if err != nil {
 		log.Fatalf("sentry.Init: %s", err)
 	}
@@ -60,5 +52,17 @@ func main() {
 	if err := cmd.NewCommand(io, config.Provide).Execute(); err != nil {
 		io.Println(err)
 		os.Exit(1)
+	}
+}
+
+func newSentryClientOptions() sentry.ClientOptions {
+	return sentry.ClientOptions{
+		Dsn:     "https://b3bcd9e4d101f927b5f1f7ac67d9b115@sentry.coscene.site/23",
+		Release: cocli.GetVersion(),
+		// Set TracesSampleRate to 1.0 to capture 100%
+		// of transactions for tracing.
+		// We recommend adjusting this value in production,
+		TracesSampleRate: 1.0,
+		AttachStacktrace: true,
 	}
 }

--- a/cmd/cocli/main.go
+++ b/cmd/cocli/main.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/coscene-io/cocli"
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/utils"
@@ -28,7 +29,8 @@ import (
 
 func main() {
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn: "https://b3bcd9e4d101f927b5f1f7ac67d9b115@sentry.coscene.site/23",
+		Dsn:     "https://b3bcd9e4d101f927b5f1f7ac67d9b115@sentry.coscene.site/23",
+		Release: cocli.GetVersion(),
 		// Set TracesSampleRate to 1.0 to capture 100%
 		// of transactions for tracing.
 		// We recommend adjusting this value in production,

--- a/cmd/cocli/main_test.go
+++ b/cmd/cocli/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/coscene-io/cocli"
+)
+
+func TestNewSentryClientOptions(t *testing.T) {
+	opts := newSentryClientOptions()
+
+	if opts.Dsn == "" {
+		t.Fatalf("expected DSN to be set")
+	}
+	if opts.Release != cocli.GetVersion() {
+		t.Fatalf("expected release %q, got %q", cocli.GetVersion(), opts.Release)
+	}
+	if opts.TracesSampleRate != 1.0 {
+		t.Fatalf("expected TracesSampleRate 1.0, got %v", opts.TracesSampleRate)
+	}
+	if !opts.AttachStacktrace {
+		t.Fatalf("expected AttachStacktrace to be true")
+	}
+}


### PR DESCRIPTION
## Summary
- Report CLI version to Sentry when an exception happens in released versions