### PR TITLE
fix(login): avoid fatal on switch prompt failures

### DIFF
--- a/pkg/cmd/login/switch.go
+++ b/pkg/cmd/login/switch.go
@@ -15,16 +15,23 @@
 package login
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/samber/lo"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
+	"golang.org/x/term"
 )
+
+var errProfileSelectionAborted = errors.New("profile selection aborted")
+
+type profileSelectorFn func(profiles []*config.Profile, currentProfile string) (*config.Profile, error)
+type headlessDetectorFn func() bool
 
 func NewSwitchCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(string) config.Provider) *cobra.Command {
 	cmd := &cobra.Command{
@@ -32,34 +39,62 @@ func NewSwitchCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func
 		Short:                 "Switch to another login profile.",
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(0),
-		Run: func(cmd *cobra.Command, args []string) {
-			cfg := getProvider(*cfgPath)
-			pm, _ := cfg.GetProfileManager()
-
-			currentProfileName := ""
-			if current := pm.GetCurrentProfile(); current != nil {
-				currentProfileName = current.Name
-			}
-			profile, err := promptForProfile(pm.GetProfiles(), currentProfileName)
-			if err != nil {
-				log.Fatalf("Failed to prompt for select profile: %v", err)
-			}
-
-			err = pm.SwitchProfile(profile.Name)
-			if err != nil {
-				log.Fatalf("Failed to switch to profile %s: %v", profile.Name, err)
-			}
-
-			if err = cfg.Persist(pm); err != nil {
-				log.Fatalf("Failed to persist profile manager: %v", err)
-			}
-
-			curProfile := pm.GetCurrentProfile()
-			io.Printf("Successfully switched to profile:\n%s\n", curProfile)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSwitch(*cfgPath, io, getProvider, promptForProfile, isHeadlessEnvironment)
 		},
 	}
 
 	return cmd
+}
+
+func runSwitch(
+	cfgPath string,
+	io *iostreams.IOStreams,
+	getProvider func(string) config.Provider,
+	selectProfile profileSelectorFn,
+	isHeadless headlessDetectorFn,
+) error {
+	cfg := getProvider(cfgPath)
+	pm, err := cfg.GetProfileManager()
+	if err != nil {
+		return fmt.Errorf("failed to get profile manager: %w", err)
+	}
+
+	profiles := pm.GetProfiles()
+	if len(profiles) == 0 {
+		return fmt.Errorf("no login profiles found")
+	}
+
+	currentProfileName := ""
+	if current := pm.GetCurrentProfile(); current != nil {
+		currentProfileName = current.Name
+	}
+
+	profile, err := selectProfile(profiles, currentProfileName)
+	if err != nil {
+		if errors.Is(err, errProfileSelectionAborted) {
+			io.Println("Profile switch cancelled.")
+			return nil
+		}
+		if isHeadless() {
+			return fmt.Errorf(
+				"unable to prompt for profile selection in non-interactive mode, use `cocli login set -n <profile-name>` instead",
+			)
+		}
+		return fmt.Errorf("failed to prompt for select profile: %w", err)
+	}
+
+	if err = pm.SwitchProfile(profile.Name); err != nil {
+		return fmt.Errorf("failed to switch to profile %s: %w", profile.Name, err)
+	}
+
+	if err = cfg.Persist(pm); err != nil {
+		return fmt.Errorf("failed to persist profile manager: %w", err)
+	}
+
+	curProfile := pm.GetCurrentProfile()
+	io.Printf("Successfully switched to profile:\n%s\n", curProfile)
+	return nil
 }
 
 type selectProfileModel struct {
@@ -119,11 +154,23 @@ func (m selectProfileModel) View() string {
 }
 
 func promptForProfile(profiles []*config.Profile, currentProfile string) (*config.Profile, error) {
+	if len(profiles) == 0 {
+		return nil, fmt.Errorf("no profiles found")
+	}
+	if len(profiles) == 1 {
+		return profiles[0], nil
+	}
+
 	profileNames := lo.Map(profiles, func(p *config.Profile, _ int) string { return p.Name })
+	cursor := slices.Index(profileNames, currentProfile)
+	if cursor < 0 {
+		cursor = 0
+	}
+
 	p := tea.NewProgram(selectProfileModel{
 		profiles:   profiles,
-		initCursor: slices.Index(profileNames, currentProfile),
-		cursor:     slices.Index(profileNames, currentProfile),
+		initCursor: cursor,
+		cursor:     cursor,
 		selected:   -1,
 	})
 	finalModel, err := p.Run()
@@ -132,7 +179,20 @@ func promptForProfile(profiles []*config.Profile, currentProfile string) (*confi
 	}
 	selected := finalModel.(selectProfileModel).selected
 	if selected < 0 {
-		return nil, fmt.Errorf("prompt failed")
+		return nil, errProfileSelectionAborted
 	}
 	return profiles[selected], nil
+}
+
+func isHeadlessEnvironment() bool {
+	if !term.IsTerminal(int(os.Stdin.Fd())) || !term.IsTerminal(int(os.Stdout.Fd())) {
+		return true
+	}
+	if os.Getenv("CI") == "true" {
+		return true
+	}
+	if os.Getenv("TERM") == "dumb" {
+		return true
+	}
+	return false
 }

--- a/pkg/cmd/login/switch_test.go
+++ b/pkg/cmd/login/switch_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package login
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/coscene-io/cocli/internal/apimocks"
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunSwitch(t *testing.T) {
+	t.Run("selection cancelled", func(t *testing.T) {
+		mockProvider := apimocks.NewMockProvider(t)
+		buf := new(bytes.Buffer)
+		io := iostreams.Test(nil, buf, buf)
+
+		err := runSwitch(
+			"test-config.yaml",
+			io,
+			func(string) config.Provider { return mockProvider },
+			func(_ []*config.Profile, _ string) (*config.Profile, error) {
+				return nil, errProfileSelectionAborted
+			},
+			func() bool { return false },
+		)
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "Profile switch cancelled.")
+	})
+
+	t.Run("prompt failed in headless mode", func(t *testing.T) {
+		mockProvider := apimocks.NewMockProvider(t)
+		io := iostreams.Test(nil, &bytes.Buffer{}, &bytes.Buffer{})
+
+		err := runSwitch(
+			"test-config.yaml",
+			io,
+			func(string) config.Provider { return mockProvider },
+			func(_ []*config.Profile, _ string) (*config.Profile, error) {
+				return nil, errors.New("prompt failed")
+			},
+			func() bool { return true },
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-interactive mode")
+		assert.Contains(t, err.Error(), "cocli login set -n <profile-name>")
+	})
+
+	t.Run("switch success", func(t *testing.T) {
+		mockProvider := apimocks.NewMockProvider(t)
+		mockProvider.ProfileManager().Profiles = []*config.Profile{
+			{
+				Name:        "profile-1",
+				EndPoint:    "https://openapi.mock1.coscene.com",
+				Token:       "token-1",
+				Org:         "org",
+				ProjectSlug: "project-1",
+				ProjectName: "project-1",
+			},
+			{
+				Name:        "profile-2",
+				EndPoint:    "https://openapi.mock2.coscene.com",
+				Token:       "token-2",
+				Org:         "org",
+				ProjectSlug: "project-2",
+				ProjectName: "project-2",
+			},
+		}
+		mockProvider.ProfileManager().CurrentProfile = "profile-1"
+		buf := new(bytes.Buffer)
+		io := iostreams.Test(nil, buf, buf)
+
+		err := runSwitch(
+			"test-config.yaml",
+			io,
+			func(string) config.Provider { return mockProvider },
+			func(profiles []*config.Profile, _ string) (*config.Profile, error) {
+				return profiles[1], nil
+			},
+			func() bool { return false },
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "profile-2", mockProvider.ProfileManager().CurrentProfile)
+		assert.Contains(t, buf.String(), "Successfully switched to profile:")
+	})
+
+	t.Run("empty profile manager", func(t *testing.T) {
+		mockProvider := apimocks.NewMockProvider(t)
+		mockProvider.ProfileManager().Profiles = []*config.Profile{}
+		mockProvider.ProfileManager().CurrentProfile = ""
+		io := iostreams.Test(nil, &bytes.Buffer{}, &bytes.Buffer{})
+
+		err := runSwitch(
+			"test-config.yaml",
+			io,
+			func(string) config.Provider { return mockProvider },
+			func(_ []*config.Profile, _ string) (*config.Profile, error) {
+				return nil, nil
+			},
+			func() bool { return false },
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no login profiles found")
+	})
+}
+
+func TestPromptForProfileEmpty(t *testing.T) {
+	_, err := promptForProfile([]*config.Profile{}, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no profiles found")
+}


### PR DESCRIPTION
## Summary
- convert \Login incorrect
login:  to return structured errors via RunE instead of calling fatal
- handle prompt cancel as a clean exit without crashing
- add headless/non-interactive fallback guidance and guard empty/single-profile selection paths
- add focused tests for cancel, headless failure, success, and empty-profile behavior

## Testing
- go test ./pkg/cmd/login
- go test ./pkg/cmd/...