### PR TITLE
Support separate CN/IO release channels for coCLI

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,12 +17,44 @@ jobs:
         include:
           - arch: amd64
             os: linux
+            channel: cn
+            base_api_endpoint: https://openapi.coscene.cn
+            download_base_url: https://download.coscene.cn/
           - arch: amd64
             os: darwin
+            channel: cn
+            base_api_endpoint: https://openapi.coscene.cn
+            download_base_url: https://download.coscene.cn/
           - arch: arm64
             os: linux
+            channel: cn
+            base_api_endpoint: https://openapi.coscene.cn
+            download_base_url: https://download.coscene.cn/
           - arch: arm64
             os: darwin
+            channel: cn
+            base_api_endpoint: https://openapi.coscene.cn
+            download_base_url: https://download.coscene.cn/
+          - arch: amd64
+            os: linux
+            channel: io
+            base_api_endpoint: https://openapi.coscene.io
+            download_base_url: https://download.coscene.io/
+          - arch: amd64
+            os: darwin
+            channel: io
+            base_api_endpoint: https://openapi.coscene.io
+            download_base_url: https://download.coscene.io/
+          - arch: arm64
+            os: linux
+            channel: io
+            base_api_endpoint: https://openapi.coscene.io
+            download_base_url: https://download.coscene.io/
+          - arch: arm64
+            os: darwin
+            channel: io
+            base_api_endpoint: https://openapi.coscene.io
+            download_base_url: https://download.coscene.io/
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -47,17 +79,17 @@ jobs:
           go-version: 1.25
       - name: Build cocli
         run: |
-          CGO_ENABLED=0 GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build-binary
+          CGO_ENABLED=0 GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} COCLI_BASE_API_ENDPOINT=${{ matrix.base_api_endpoint }} COCLI_DOWNLOAD_BASE_URL=${{ matrix.download_base_url }} make build-binary
           cp bin/cocli cocli
-          cp bin/cocli bin/cocli-${{ matrix.os }}-${{ matrix.arch }}
+          cp bin/cocli ${{ matrix.channel == 'cn' && format('bin/cocli-{0}-{1}', matrix.os, matrix.arch) || format('bin/cocli-{0}-{1}-{2}', matrix.channel, matrix.os, matrix.arch) }}
       
       # Upload to GitHub release
       - name: Upload release artifact
         uses: softprops/action-gh-release@v2
         with:
-          files: bin/cocli-${{ matrix.os }}-${{ matrix.arch }}
+          files: ${{ matrix.channel == 'cn' && format('bin/cocli-{0}-{1}', matrix.os, matrix.arch) || format('bin/cocli-{0}-{1}-{2}', matrix.channel, matrix.os, matrix.arch) }}
   
-      # Upload to oss
+      # Upload release payloads
       - name: Install gzip
         run: sudo apt-get update && sudo apt-get install -y gzip
       - name: Build release metadata files
@@ -67,24 +99,94 @@ jobs:
           echo "{\"Version\": \"${{ github.ref_name }}\", \"Sha256\": \"$SHA256SUM\"}" > ${{ matrix.os }}-${{ matrix.arch }}.json
       - name: gzip cocli
         run: gzip cocli
+      - name: Render channel install script
+        if: matrix.os == 'linux' && matrix.arch == 'amd64'
+        run: |
+          sed "s#^DOWNLOAD_BASE_URL_DEFAULT=.*#DOWNLOAD_BASE_URL_DEFAULT=\"${{ matrix.download_base_url }}\"#" scripts/install.sh > install.sh
+          chmod +x install.sh
       - name: Upload cocli to oss corresponding version
+        if: matrix.channel == 'cn'
         uses: tvrcgo/oss-action@master
         with:
           key-id: ${{ secrets.OSS_ACCESS_KEY_ID }}
           key-secret: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+          endpoint: https://oss-cn-hangzhou.aliyuncs.com
           region: oss-cn-hangzhou
           bucket: coscene-download
           assets: |
             cocli.gz:/cocli/${{ github.ref_name }}/${{ matrix.os }}-${{ matrix.arch }}.gz
-      - name: Upload cocli to oss latest
-        if: env.IS_RELEASE == 'true'
+      - name: Upload install script to oss
+        if: matrix.channel == 'cn' && matrix.os == 'linux' && matrix.arch == 'amd64'
         uses: tvrcgo/oss-action@master
         with:
           key-id: ${{ secrets.OSS_ACCESS_KEY_ID }}
           key-secret: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+          endpoint: https://oss-cn-hangzhou.aliyuncs.com
+          region: oss-cn-hangzhou
+          bucket: coscene-download
+          assets: |
+            install.sh:/cocli/install.sh
+      - name: Upload cocli to oss latest
+        if: matrix.channel == 'cn' && env.IS_RELEASE == 'true'
+        uses: tvrcgo/oss-action@master
+        with:
+          key-id: ${{ secrets.OSS_ACCESS_KEY_ID }}
+          key-secret: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+          endpoint: https://oss-cn-hangzhou.aliyuncs.com
           region: oss-cn-hangzhou
           bucket: coscene-download
           assets: |
             cocli.gz:/cocli/latest/${{ matrix.os }}-${{ matrix.arch }}.gz
             ${{ matrix.os }}-${{ matrix.arch }}.json:/cocli/${{ matrix.os }}-${{ matrix.arch }}.json
-
+      - name: Prepare io version upload
+        if: matrix.channel == 'io'
+        run: |
+          mkdir -p upload_version
+          cp cocli.gz upload_version/${{ matrix.os }}-${{ matrix.arch }}.gz
+      - name: Prepare io install script upload
+        if: matrix.channel == 'io' && matrix.os == 'linux' && matrix.arch == 'amd64'
+        run: |
+          mkdir -p upload_install
+          cp install.sh upload_install/install.sh
+      - name: Upload cocli to s3 corresponding version
+        if: matrix.channel == 'io'
+        uses: shallwefootball/s3-upload-action@master
+        with:
+          aws_key_id: ${{ secrets.S3_ARTIFACTS_ACCESS_KEY }}
+          aws_secret_access_key: ${{ secrets.S3_ARTIFACTS_ACCESS_SECRET }}
+          aws_bucket: coscene-download
+          source_dir: upload_version
+          destination_dir: cocli/${{ github.ref_name }}/
+      - name: Upload install script to s3
+        if: matrix.channel == 'io' && matrix.os == 'linux' && matrix.arch == 'amd64'
+        uses: shallwefootball/s3-upload-action@master
+        with:
+          aws_key_id: ${{ secrets.S3_ARTIFACTS_ACCESS_KEY }}
+          aws_secret_access_key: ${{ secrets.S3_ARTIFACTS_ACCESS_SECRET }}
+          aws_bucket: coscene-download
+          source_dir: upload_install
+          destination_dir: cocli/
+      - name: Prepare io latest payloads
+        if: matrix.channel == 'io' && env.IS_RELEASE == 'true'
+        run: |
+          mkdir -p upload_latest upload_metadata
+          cp cocli.gz upload_latest/${{ matrix.os }}-${{ matrix.arch }}.gz
+          cp ${{ matrix.os }}-${{ matrix.arch }}.json upload_metadata/${{ matrix.os }}-${{ matrix.arch }}.json
+      - name: Upload cocli to s3 latest
+        if: matrix.channel == 'io' && env.IS_RELEASE == 'true'
+        uses: shallwefootball/s3-upload-action@master
+        with:
+          aws_key_id: ${{ secrets.S3_ARTIFACTS_ACCESS_KEY }}
+          aws_secret_access_key: ${{ secrets.S3_ARTIFACTS_ACCESS_SECRET }}
+          aws_bucket: coscene-download
+          source_dir: upload_latest
+          destination_dir: cocli/latest/
+      - name: Upload cocli metadata to s3
+        if: matrix.channel == 'io' && env.IS_RELEASE == 'true'
+        uses: shallwefootball/s3-upload-action@master
+        with:
+          aws_key_id: ${{ secrets.S3_ARTIFACTS_ACCESS_KEY }}
+          aws_secret_access_key: ${{ secrets.S3_ARTIFACTS_ACCESS_SECRET }}
+          aws_bucket: coscene-download
+          source_dir: upload_metadata
+          destination_dir: cocli/

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -28,20 +28,20 @@ const (
 	// ConfigFilename is the name of the configuration file
 	ConfigFilename = ".cocli.yaml"
 
-	// DownloadBaseUrl is the base url for downloading files
-	DownloadBaseUrl = "https://download.coscene.cn/"
-
 	// CurrentOrgNameStr is the string for the current profile
 	CurrentOrgNameStr = "organizations/current"
-
-	// BaseApiEndpoint is the base url for the api
-	BaseApiEndpoint = "https://openapi.coscene.cn"
 
 	// MaxPageSize is the maximum page size for the api
 	MaxPageSize = 100
 )
 
 var (
+	// DownloadBaseUrl can be overridden at build time for region-specific releases.
+	DownloadBaseUrl = "https://download.coscene.cn/"
+
+	// BaseApiEndpoint can be overridden at build time for region-specific releases.
+	BaseApiEndpoint = "https://openapi.coscene.cn"
+
 	DefaultConfigPath      = defaultConfigPath()
 	DefaultUploaderDirPath = defaultUploaderDirPath()
 )

--- a/make/cocli/version.mk
+++ b/make/cocli/version.mk
@@ -6,6 +6,8 @@ GIT_TAG               := $(shell git describe --exact-match --tags --abbrev=0  2
 GIT_TREE_STATE        := $(shell if [ -z "`git status --porcelain`" ]; then echo "clean" ; else echo "dirty"; fi)
 RELEASE_TAG           := $(shell if [[ "$(GIT_TAG)" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$$ ]]; then echo "true"; else echo "false"; fi)
 VERSION               := latest
+COCLI_BASE_API_ENDPOINT ?= https://openapi.coscene.cn
+COCLI_DOWNLOAD_BASE_URL ?= https://download.coscene.cn/
 
 # VERSION is the version to be used for files in manifests and should always be latest unless we are releasing
 # we assume HEAD means you are on a tag
@@ -16,7 +18,9 @@ endif
 override LDFLAGS += \
   -X github.com/coscene-io/cocli.version=$(VERSION) \
   -X github.com/coscene-io/cocli.gitCommit=${GIT_COMMIT} \
-  -X github.com/coscene-io/cocli.gitTreeState=${GIT_TREE_STATE}
+  -X github.com/coscene-io/cocli.gitTreeState=${GIT_TREE_STATE} \
+  -X github.com/coscene-io/cocli/internal/constants.BaseApiEndpoint=$(COCLI_BASE_API_ENDPOINT) \
+  -X github.com/coscene-io/cocli/internal/constants.DownloadBaseUrl=$(COCLI_DOWNLOAD_BASE_URL)
 
 ifneq ($(GIT_TAG),)
 override LDFLAGS += -X github.com/coscene-io/cocli.gitTag=${GIT_TAG}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,6 +5,8 @@ set -u
 
 VERSION="latest"
 FILE_NAME="cocli"
+DOWNLOAD_BASE_URL_DEFAULT="https://download.coscene.cn"
+DOWNLOAD_BASE_URL="${COCLI_DOWNLOAD_BASE_URL:-$DOWNLOAD_BASE_URL_DEFAULT}"
 
 if [ $# -eq 1 ]; then
     VERSION=$1
@@ -40,7 +42,7 @@ else
     echo "Unsupported OS: $(uname -s)"
     exit 1
 fi
-URL="https://download.coscene.cn/cocli/${VERSION}/${CLI_OS}-${ARCH}.gz"
+URL="${DOWNLOAD_BASE_URL%/}/cocli/${VERSION}/${CLI_OS}-${ARCH}.gz"
 echo "Downloading from: $URL"
 curl -XGET "$URL" > $FILE_NAME.gz
 gzip -d $FILE_NAME.gz


### PR DESCRIPTION
现象
- 外网安装脚本和发布链路仍然会落到 CN 产物，海外对象存储中的 artifacts 无法作为独立通道使用。
- 现有 install.sh 只有一份固定脚本，无法在发布时分别指向 CN / IO 下载源。

根因分析
- 发布 workflow 只有一套 os/arch 构建矩阵，只上传阿里云 OSS。
- 默认 API endpoint 和下载源写死在代码常量里，无法按通道生成不同 binary。
- install.sh 没有模板化，发布时无法按环境渲染。

修复方案
- 将默认 API endpoint 与下载源改为构建时注入，保持仓库默认值仍为 CN。
- 在 release workflow 中新增 cn/io 通道矩阵：CN 继续走现有 OSS 路径；IO 新增上传到 us-east-1 的 S3 bucket `coscene-download`。
- install.sh 保持单模板维护，在发布时按通道渲染后分别上传到对应环境的 `cocli/install.sh`。
- 保持 CN 现有 artifact 名称、对象路径与 latest 元数据路径不变，避免现网用户回退。

验证
- `go test ./...`
- `sh -n scripts/install.sh`
- 渲染 IO install.sh 并做语法检查，确认默认下载源为 `https://download.coscene.io/`
- 构建 IO binary 后检查 `cocli login add --help` 默认 endpoint 为 `https://openapi.coscene.io`
- 再构建默认 CN binary，确认默认 endpoint 仍为 `https://openapi.coscene.cn`

补充说明
- 当前 CD workflow 触发条件已包含 `released` 和 `prereleased`，因此从 `dev` 分支打 RC tag 时，CN/IO 双通道发布链路都可以直接用于测试。