### PR TITLE
Show release channel and endpoint context in CLI output

### DIFF
--- a/internal/constants/release_context.go
+++ b/internal/constants/release_context.go
@@ -1,0 +1,54 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+import (
+	"net/url"
+	"strings"
+)
+
+func ReleaseChannelDisplayName() string {
+	return releaseChannelDisplayName(BaseApiEndpoint, DownloadBaseUrl)
+}
+
+func releaseChannelDisplayName(baseAPIEndpoint, downloadBaseURL string) string {
+	apiHost := hostFromURL(baseAPIEndpoint)
+	downloadHost := hostFromURL(downloadBaseURL)
+
+	switch {
+	case apiHost == "openapi.coscene.cn" && downloadHost == "download.coscene.cn":
+		return "CN"
+	case apiHost == "openapi.coscene.io" && downloadHost == "download.coscene.io":
+		return "IO"
+	default:
+		return "Custom"
+	}
+}
+
+func hostFromURL(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err == nil && parsed.Host != "" {
+		return strings.ToLower(parsed.Host)
+	}
+
+	trimmed := strings.TrimSpace(rawURL)
+	trimmed = strings.TrimPrefix(trimmed, "https://")
+	trimmed = strings.TrimPrefix(trimmed, "http://")
+	return strings.ToLower(strings.TrimSuffix(trimmed, "/"))
+}

--- a/internal/constants/release_context_test.go
+++ b/internal/constants/release_context_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+import "testing"
+
+func TestReleaseChannelDisplayName(t *testing.T) {
+	tests := []struct {
+		name            string
+		baseAPIEndpoint string
+		downloadBaseURL string
+		want            string
+	}{
+		{
+			name:            "cn release channel",
+			baseAPIEndpoint: "https://openapi.coscene.cn",
+			downloadBaseURL: "https://download.coscene.cn/",
+			want:            "CN",
+		},
+		{
+			name:            "io release channel",
+			baseAPIEndpoint: "https://openapi.coscene.io",
+			downloadBaseURL: "https://download.coscene.io/",
+			want:            "IO",
+		},
+		{
+			name:            "custom mixed channel",
+			baseAPIEndpoint: "https://openapi.coscene.io",
+			downloadBaseURL: "https://download.coscene.cn/",
+			want:            "Custom",
+		},
+		{
+			name:            "custom arbitrary endpoints",
+			baseAPIEndpoint: "https://openapi.example.com",
+			downloadBaseURL: "https://download.example.com/",
+			want:            "Custom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := releaseChannelDisplayName(tt.baseAPIEndpoint, tt.downloadBaseURL)
+			if got != tt.want {
+				t.Fatalf("want %q, got %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/cmd/registry/create_credential.go
+++ b/pkg/cmd/registry/create_credential.go
@@ -37,6 +37,7 @@ func NewCreateCredentialCommand(cfgPath *string, io *iostreams.IOStreams, getPro
 			if err != nil {
 				log.Fatalf("failed to load profile manager: %v", err)
 			}
+			endpoint := pm.GetCurrentProfile().EndPoint
 
 			cred, err := pm.ContainerRegistryCli().CreateBasicCredential(cmd.Context())
 			if err != nil {
@@ -44,6 +45,10 @@ func NewCreateCredentialCommand(cfgPath *string, io *iostreams.IOStreams, getPro
 			}
 
 			if outputFormat == "" {
+				io.Printf("base API endpoint: %s\n", endpoint)
+				if host, inferErr := inferRegistryHost(endpoint, ""); inferErr == nil {
+					io.Printf("registry host: %s\n", host)
+				}
 				io.Printf("username: %s\n", cred.GetUsername())
 				io.Printf("password: %s\n", cred.GetPassword())
 				return

--- a/pkg/cmd/registry/login.go
+++ b/pkg/cmd/registry/login.go
@@ -47,6 +47,9 @@ func NewLoginCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(
 				log.Fatalf("%v", err)
 			}
 
+			io.Printf("Using base API endpoint: %s\n", endpoint)
+			io.Printf("Resolved registry host: %s\n", host)
+
 			cred, err := pm.ContainerRegistryCli().CreateBasicCredential(cmd.Context())
 			if err != nil {
 				log.Fatalf("failed to create basic credential: %v", err)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -45,8 +46,9 @@ func NewCommand(io *iostreams.IOStreams, getProvider ProviderGetter) *cobra.Comm
 
 	cmd := &cobra.Command{
 		Use:     constants.CLIName,
-		Short:   "",
-		Version: cocli.GetVersion(),
+		Short:   "coScene CLI",
+		Long:    rootLongDescription(),
+		Version: rootVersionString(),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			log.SetLevel(log.DebugLevel)
 			level, err := log.ParseLevel(logLevel)
@@ -104,7 +106,6 @@ func NewCommand(io *iostreams.IOStreams, getProvider ProviderGetter) *cobra.Comm
 			}
 		},
 	}
-
 	cmd.PersistentFlags().StringVar(&cfgPath, "config", constants.DefaultConfigPath, "config file path")
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "log level, one of: trace|debug|info|warn|error")
 
@@ -119,4 +120,23 @@ func NewCommand(io *iostreams.IOStreams, getProvider ProviderGetter) *cobra.Comm
 	cmd.AddCommand(NewUpdateCommand(io))
 
 	return cmd
+}
+
+func rootLongDescription() string {
+	return fmt.Sprintf(
+		"coScene CLI\n\nRelease channel: %s\nBase API endpoint: %s\nDownload base: %s",
+		constants.ReleaseChannelDisplayName(),
+		constants.BaseApiEndpoint,
+		constants.DownloadBaseUrl,
+	)
+}
+
+func rootVersionString() string {
+	return fmt.Sprintf(
+		"%s\nRelease channel: %s\nBase API endpoint: %s\nDownload base: %s",
+		cocli.GetVersion(),
+		constants.ReleaseChannelDisplayName(),
+		constants.BaseApiEndpoint,
+		constants.DownloadBaseUrl,
+	)
 }

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -41,6 +41,8 @@ func TestRootCommand(t *testing.T) {
 
 		output := buf.String()
 		assert.Contains(t, output, "cocli version")
+		assert.Contains(t, output, "Release channel:")
+		assert.Contains(t, output, "Base API endpoint:")
 	})
 
 	t.Run("Help flag", func(t *testing.T) {
@@ -54,6 +56,8 @@ func TestRootCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		output := buf.String()
+		assert.Contains(t, output, "Release channel:")
+		assert.Contains(t, output, "Base API endpoint:")
 		assert.Contains(t, output, "Usage:")
 		assert.Contains(t, output, "Available Commands:")
 	})

--- a/pkg/cmd/update.go
+++ b/pkg/cmd/update.go
@@ -34,6 +34,10 @@ func NewUpdateCommand(io *iostreams.IOStreams) *cobra.Command {
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
+			io.Printf("Release channel: %s\n", constants.ReleaseChannelDisplayName())
+			io.Printf("Base API endpoint: %s\n", constants.BaseApiEndpoint)
+			io.Printf("Download base: %s\n", constants.DownloadBaseUrl)
+
 			var updater = &selfupdate.Updater{
 				CurrentVersion: cocli.GetVersion(),
 				ApiURL:         constants.DownloadBaseUrl,


### PR DESCRIPTION
现象
- 现在很难从 `cocli --version`、help、`update`、registry/docker 相关命令的输出里快速判断当前 binary 是 CN 还是 IO。
- 这会让人工排查和 AI 自动检查都要额外猜测环境。

根因分析
- release channel 信息只体现在构建时注入的默认域名里，没有在命令输出中显式展示。
- `update` 和 registry 相关命令没有把当前使用的 base endpoint / registry host 打印出来。

修复方案
- 在 root help 和 `--version` 输出中展示 release channel、base API endpoint、download base。
- 在 `update` 输出中展示当前 release channel、base API endpoint、download base。
- 在 `registry login` 输出中展示当前 profile 的 base API endpoint 和解析出的 registry host。
- 在 `registry create-credential` 的默认文本输出中展示 base API endpoint / registry host；结构化输出 `-o json|yaml|table` 保持不变，避免破坏机器解析。
- 新增一个轻量 helper 统一判断当前 release channel。

验证
- `go test ./...`
- `make build-binary && ./bin/cocli --version`
- `./bin/cocli --help`
- `CGO_ENABLED=0 COCLI_BASE_API_ENDPOINT=https://openapi.coscene.io COCLI_DOWNLOAD_BASE_URL=https://download.coscene.io/ make build-binary && ./bin/cocli --version`
- `./bin/cocli login add --help` 确认 IO 构建下默认 endpoint 为 `https://openapi.coscene.io`

说明
- 这次没有新增根级 `-v`，因为现有很多子命令已经把 `-v` 用作 `--verbose`，硬加会引入 flag 冲突。