### PR TITLE
Force GitHub Actions workflows onto Node 24

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -6,6 +6,9 @@ on:
       - released
       - prereleased
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,10 @@ on:
     branches: [ main, dev ]
   pull_request:
     branches: [ main, dev ]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, dev ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
现象
- GitHub Actions 一直在报 `Node.js 20 actions are deprecated` warning。
- 当前 repo 里的 warning 不只出现在 CD，也出现在 CI / Tests，因为有多处 action 仍声明 `using: node20`。

根因分析
- 目前使用的 `softprops/action-gh-release@v2`、`tvrcgo/oss-action@master`、`shallwefootball/s3-upload-action@master` 仍声明运行在 Node 20。
- CI / Tests 里用到的部分 action 也会触发同类 warning。

修复方案
- 按 GitHub warning 自带的推荐做法，在 workflow 级别增加 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`。
- 范围覆盖 `cd.yaml`、`ci.yaml`、`test.yaml`，让所有 JS action 统一在 Node 24 下运行。

为什么先这样修
- 改动最小，不需要立刻重写发布和上传步骤。
- warning 里明确给了这个过渡方案。
- 之后如果某个第三方 action 在 Node 24 下有兼容问题，再有针对性地替换对应 action。

验证
- 本次只改 workflow YAML，语法结构已检查。
- merge 后可先看 `dev` 分支上的 CI / Tests 是否不再出现 Node 20 warning。
- CD 需要在下一次 release / prerelease 事件中确认 warning 是否消失。