### PR TITLE
Reduce duplication in CD workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -14,50 +14,20 @@ jobs:
   build-and-upload-cli-artifact:
     strategy:
       matrix:
-        include:
-          - arch: amd64
-            os: linux
-            channel: cn
-            base_api_endpoint: https://openapi.coscene.cn
-            download_base_url: https://download.coscene.cn/
-          - arch: amd64
-            os: darwin
-            channel: cn
-            base_api_endpoint: https://openapi.coscene.cn
-            download_base_url: https://download.coscene.cn/
-          - arch: arm64
-            os: linux
-            channel: cn
-            base_api_endpoint: https://openapi.coscene.cn
-            download_base_url: https://download.coscene.cn/
-          - arch: arm64
-            os: darwin
-            channel: cn
-            base_api_endpoint: https://openapi.coscene.cn
-            download_base_url: https://download.coscene.cn/
-          - arch: amd64
-            os: linux
-            channel: io
-            base_api_endpoint: https://openapi.coscene.io
-            download_base_url: https://download.coscene.io/
-          - arch: amd64
-            os: darwin
-            channel: io
-            base_api_endpoint: https://openapi.coscene.io
-            download_base_url: https://download.coscene.io/
-          - arch: arm64
-            os: linux
-            channel: io
-            base_api_endpoint: https://openapi.coscene.io
-            download_base_url: https://download.coscene.io/
-          - arch: arm64
-            os: darwin
-            channel: io
-            base_api_endpoint: https://openapi.coscene.io
-            download_base_url: https://download.coscene.io/
+        channel: [cn, io]
+        os: [linux, darwin]
+        arch: [amd64, arm64]
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      BASE_API_ENDPOINT: ${{ matrix.channel == 'cn' && 'https://openapi.coscene.cn' || 'https://openapi.coscene.io' }}
+      DOWNLOAD_BASE_URL: ${{ matrix.channel == 'cn' && 'https://download.coscene.cn/' || 'https://download.coscene.io/' }}
+      RELEASE_ARTIFACT_PATH: ${{ matrix.channel == 'cn' && format('bin/cocli-{0}-{1}', matrix.os, matrix.arch) || format('bin/cocli-{0}-{1}-{2}', matrix.channel, matrix.os, matrix.arch) }}
+      PAYLOAD_NAME: ${{ format('{0}-{1}.gz', matrix.os, matrix.arch) }}
+      METADATA_NAME: ${{ format('{0}-{1}.json', matrix.os, matrix.arch) }}
+      TARGET_OS: ${{ matrix.os }}
+      TARGET_ARCH: ${{ matrix.arch }}
     steps:
       # Check version
       - name: Check if version is semantic
@@ -79,15 +49,15 @@ jobs:
           go-version: 1.25
       - name: Build cocli
         run: |
-          CGO_ENABLED=0 GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} COCLI_BASE_API_ENDPOINT=${{ matrix.base_api_endpoint }} COCLI_DOWNLOAD_BASE_URL=${{ matrix.download_base_url }} make build-binary
+          CGO_ENABLED=0 GOOS="${TARGET_OS}" GOARCH="${TARGET_ARCH}" COCLI_BASE_API_ENDPOINT="${BASE_API_ENDPOINT}" COCLI_DOWNLOAD_BASE_URL="${DOWNLOAD_BASE_URL}" make build-binary
           cp bin/cocli cocli
-          cp bin/cocli ${{ matrix.channel == 'cn' && format('bin/cocli-{0}-{1}', matrix.os, matrix.arch) || format('bin/cocli-{0}-{1}-{2}', matrix.channel, matrix.os, matrix.arch) }}
+          cp bin/cocli "${RELEASE_ARTIFACT_PATH}"
       
       # Upload to GitHub release
       - name: Upload release artifact
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ matrix.channel == 'cn' && format('bin/cocli-{0}-{1}', matrix.os, matrix.arch) || format('bin/cocli-{0}-{1}-{2}', matrix.channel, matrix.os, matrix.arch) }}
+          files: ${{ env.RELEASE_ARTIFACT_PATH }}
   
       # Upload release payloads
       - name: Install gzip
@@ -96,14 +66,26 @@ jobs:
         if: env.IS_RELEASE == 'true'
         run: |
           SHA256SUM=$(sha256sum cocli | awk '{print $1}' | xxd -r -p | base64) 
-          echo "{\"Version\": \"${{ github.ref_name }}\", \"Sha256\": \"$SHA256SUM\"}" > ${{ matrix.os }}-${{ matrix.arch }}.json
+          echo "{\"Version\": \"${{ github.ref_name }}\", \"Sha256\": \"$SHA256SUM\"}" > "${METADATA_NAME}"
       - name: gzip cocli
         run: gzip cocli
-      - name: Render channel install script
-        if: matrix.os == 'linux' && matrix.arch == 'amd64'
+      - name: Prepare release payloads
         run: |
-          sed "s#^DOWNLOAD_BASE_URL_DEFAULT=.*#DOWNLOAD_BASE_URL_DEFAULT=\"${{ matrix.download_base_url }}\"#" scripts/install.sh > install.sh
-          chmod +x install.sh
+          mkdir -p upload_version
+          cp cocli.gz "upload_version/${PAYLOAD_NAME}"
+
+          if [ "${IS_RELEASE}" = "true" ]; then
+            mkdir -p upload_latest upload_metadata
+            cp cocli.gz "upload_latest/${PAYLOAD_NAME}"
+            cp "${METADATA_NAME}" "upload_metadata/${METADATA_NAME}"
+          fi
+
+          if [ "${TARGET_OS}" = "linux" ] && [ "${TARGET_ARCH}" = "amd64" ]; then
+            sed "s#^DOWNLOAD_BASE_URL_DEFAULT=.*#DOWNLOAD_BASE_URL_DEFAULT=\"${DOWNLOAD_BASE_URL}\"#" scripts/install.sh > install.sh
+            chmod +x install.sh
+            mkdir -p upload_install
+            cp install.sh upload_install/install.sh
+          fi
       - name: Upload cocli to oss corresponding version
         if: matrix.channel == 'cn'
         uses: tvrcgo/oss-action@master
@@ -114,7 +96,7 @@ jobs:
           region: oss-cn-hangzhou
           bucket: coscene-download
           assets: |
-            cocli.gz:/cocli/${{ github.ref_name }}/${{ matrix.os }}-${{ matrix.arch }}.gz
+            upload_version/${{ env.PAYLOAD_NAME }}:/cocli/${{ github.ref_name }}/${{ env.PAYLOAD_NAME }}
       - name: Upload install script to oss
         if: matrix.channel == 'cn' && matrix.os == 'linux' && matrix.arch == 'amd64'
         uses: tvrcgo/oss-action@master
@@ -125,7 +107,7 @@ jobs:
           region: oss-cn-hangzhou
           bucket: coscene-download
           assets: |
-            install.sh:/cocli/install.sh
+            upload_install/install.sh:/cocli/install.sh
       - name: Upload cocli to oss latest
         if: matrix.channel == 'cn' && env.IS_RELEASE == 'true'
         uses: tvrcgo/oss-action@master
@@ -136,18 +118,8 @@ jobs:
           region: oss-cn-hangzhou
           bucket: coscene-download
           assets: |
-            cocli.gz:/cocli/latest/${{ matrix.os }}-${{ matrix.arch }}.gz
-            ${{ matrix.os }}-${{ matrix.arch }}.json:/cocli/${{ matrix.os }}-${{ matrix.arch }}.json
-      - name: Prepare io version upload
-        if: matrix.channel == 'io'
-        run: |
-          mkdir -p upload_version
-          cp cocli.gz upload_version/${{ matrix.os }}-${{ matrix.arch }}.gz
-      - name: Prepare io install script upload
-        if: matrix.channel == 'io' && matrix.os == 'linux' && matrix.arch == 'amd64'
-        run: |
-          mkdir -p upload_install
-          cp install.sh upload_install/install.sh
+            upload_latest/${{ env.PAYLOAD_NAME }}:/cocli/latest/${{ env.PAYLOAD_NAME }}
+            upload_metadata/${{ env.METADATA_NAME }}:/cocli/${{ env.METADATA_NAME }}
       - name: Upload cocli to s3 corresponding version
         if: matrix.channel == 'io'
         uses: shallwefootball/s3-upload-action@master
@@ -166,12 +138,6 @@ jobs:
           aws_bucket: coscene-download
           source_dir: upload_install
           destination_dir: cocli/
-      - name: Prepare io latest payloads
-        if: matrix.channel == 'io' && env.IS_RELEASE == 'true'
-        run: |
-          mkdir -p upload_latest upload_metadata
-          cp cocli.gz upload_latest/${{ matrix.os }}-${{ matrix.arch }}.gz
-          cp ${{ matrix.os }}-${{ matrix.arch }}.json upload_metadata/${{ matrix.os }}-${{ matrix.arch }}.json
       - name: Upload cocli to s3 latest
         if: matrix.channel == 'io' && env.IS_RELEASE == 'true'
         uses: shallwefootball/s3-upload-action@master


### PR DESCRIPTION
现象
- `.github/workflows/cd.yaml` 里有较多重复配置：8 组 `matrix.include`、重复的 artifact 命名表达式，以及分散的 payload 准备步骤。

修复方案
- 将 matrix 收敛为 `channel x os x arch` 三个维度。
- 将 `base_api_endpoint`、`download_base_url`、artifact 名称、payload 名称等派生信息统一放到 job `env`。
- 合并原本分散的 payload / install.sh / latest metadata 预处理步骤为一个 `Prepare release payloads`。
- 保留 OSS 和 S3 两套上传 action，不强行合并跨云逻辑，避免为了 DRY 牺牲可读性和稳定性。

不变项
- 仍然发布 8 个 job（CN/IO x Linux/Darwin x amd64/arm64）。
- CN / IO 的对象路径、install.sh 路径、release artifact 命名保持不变。
- `released` / `prereleased` 触发逻辑保持不变。

验证
- 用 Ruby 标准库做了 YAML 解析检查：`yaml ok`。
- 这次只改 workflow 结构，没有改发布语义；真实行为需要在下一次 release / prerelease 中验证。