### PR TITLE
[codex] add focused coverage tests

### DIFF
--- a/api/action_extra_test.go
+++ b/api/action_extra_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"testing"
+
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	openv1alpha1service "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/services"
+	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/internal/constants"
+	"github.com/coscene-io/cocli/internal/name"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActionClientGetAndList(t *testing.T) {
+	actionName := &name.Action{ProjectID: "p1", ID: "a1"}
+	mock := &mockActionServiceClient{
+		getActionFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.GetActionRequest]) (*connect.Response[openv1alpha1resource.Action], error) {
+			assert.Equal(t, "projects/p1/actions/a1", req.Msg.Name)
+			return connect.NewResponse(&openv1alpha1resource.Action{Name: req.Msg.Name}), nil
+		},
+		listActionsFunc: func() func(context.Context, *connect.Request[openv1alpha1service.ListActionsRequest]) (*connect.Response[openv1alpha1service.ListActionsResponse], error) {
+			calls := 0
+			return func(ctx context.Context, req *connect.Request[openv1alpha1service.ListActionsRequest]) (*connect.Response[openv1alpha1service.ListActionsResponse], error) {
+				assert.Equal(t, "projects/p1", req.Msg.Parent)
+				assert.Equal(t, int32(constants.MaxPageSize), req.Msg.PageSize)
+				if calls == 0 {
+					calls++
+					actions := make([]*openv1alpha1resource.Action, constants.MaxPageSize)
+					for i := range actions {
+						actions[i] = &openv1alpha1resource.Action{Name: "first-page"}
+					}
+					return connect.NewResponse(&openv1alpha1service.ListActionsResponse{Actions: actions}), nil
+				}
+				assert.Equal(t, int32(constants.MaxPageSize), req.Msg.Skip)
+				return connect.NewResponse(&openv1alpha1service.ListActionsResponse{
+					Actions: []*openv1alpha1resource.Action{{Name: "last-page"}},
+				}), nil
+			}
+		}(),
+	}
+	client := NewActionClient(mock, nil)
+
+	action, err := client.GetByName(context.Background(), actionName)
+	require.NoError(t, err)
+	assert.Equal(t, "projects/p1/actions/a1", action.Name)
+
+	actions, err := client.ListAllActions(context.Background(), &ListActionsOptions{Parent: "projects/p1"})
+	require.NoError(t, err)
+	assert.Len(t, actions, constants.MaxPageSize+1)
+	assert.Equal(t, "last-page", actions[len(actions)-1].Name)
+}
+
+func TestActionClientCreateAndListRuns(t *testing.T) {
+	recordName := &name.Record{ProjectID: "p1", RecordID: "r1"}
+	action := &openv1alpha1resource.Action{Name: "projects/p1/actions/a1"}
+	mock := &mockActionRunServiceClient{
+		createActionRunFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.CreateActionRunRequest]) (*connect.Response[openv1alpha1resource.ActionRun], error) {
+			assert.Equal(t, "projects/p1", req.Msg.Parent)
+			assert.Equal(t, action, req.Msg.ActionRun.Action)
+			assert.Equal(t, []string{"projects/p1/records/r1"}, req.Msg.ActionRun.Match.Records)
+			return connect.NewResponse(&openv1alpha1resource.ActionRun{}), nil
+		},
+		listActionRunsFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.ListActionRunsRequest]) (*connect.Response[openv1alpha1service.ListActionRunsResponse], error) {
+			assert.Equal(t, "projects/p1", req.Msg.Parent)
+			assert.Equal(t, `match.records==["projects/p1/records/r1"]`, req.Msg.Filter)
+			return connect.NewResponse(&openv1alpha1service.ListActionRunsResponse{
+				ActionRuns: []*openv1alpha1resource.ActionRun{{Name: "projects/p1/actionRuns/run1"}},
+			}), nil
+		},
+	}
+	client := NewActionClient(nil, mock)
+
+	require.NoError(t, client.CreateActionRun(context.Background(), action, recordName))
+
+	runs, err := client.ListAllActionRuns(context.Background(), &ListActionRunsOptions{
+		Parent:      "projects/p1",
+		RecordNames: []*name.Record{recordName},
+	})
+	require.NoError(t, err)
+	require.Len(t, runs, 1)
+	assert.Equal(t, "projects/p1/actionRuns/run1", runs[0].Name)
+}
+
+func TestActionClientActionId2Name(t *testing.T) {
+	uuid := "d9b9d56b-0d43-4719-b7cc-0d7e6616bb8a"
+	mock := &mockActionServiceClient{
+		getActionFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.GetActionRequest]) (*connect.Response[openv1alpha1resource.Action], error) {
+			assert.Equal(t, "projects/p1/actions/"+uuid, req.Msg.Name)
+			return connect.NewResponse(&openv1alpha1resource.Action{Name: req.Msg.Name}), nil
+		},
+	}
+	client := NewActionClient(mock, nil)
+	proj := &name.Project{ProjectID: "p1"}
+
+	byID, err := client.ActionId2Name(context.Background(), uuid, proj)
+	require.NoError(t, err)
+	assert.Equal(t, "projects/p1/actions/"+uuid, byID.String())
+
+	byName, err := client.ActionId2Name(context.Background(), "projects/p2/actions/a2", proj)
+	require.NoError(t, err)
+	assert.Equal(t, "projects/p2/actions/a2", byName.String())
+
+	_, err = client.ActionId2Name(context.Background(), "not-a-uuid", proj)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid action id or name")
+}

--- a/api/api_utils/auth_interceptor_extra_test.go
+++ b/api/api_utils/auth_interceptor_extra_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api_utils
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func TestAuthInterceptorAddsAPIKeyHeaders(t *testing.T) {
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("apikey:secret"))
+	interceptor := AuthInterceptor("secret")
+
+	wrapped := interceptor.WrapUnary(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		assert.Equal(t, want, req.Header().Get("Authorization"))
+		assert.Equal(t, want, req.Header().Get("x-cos-auth-token"))
+		return connect.NewResponse(&emptypb.Empty{}), nil
+	})
+
+	_, err := wrapped(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.NoError(t, err)
+}
+
+func TestAuthInterceptorKeepsJWTBearerToken(t *testing.T) {
+	interceptor := AuthInterceptor("header.payload.signature")
+
+	wrapped := interceptor.WrapUnary(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		assert.Equal(t, "Bearer header.payload.signature", req.Header().Get("Authorization"))
+		assert.Equal(t, "Bearer header.payload.signature", req.Header().Get("x-cos-auth-token"))
+		return connect.NewResponse(&emptypb.Empty{}), nil
+	})
+
+	_, err := wrapped(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.NoError(t, err)
+}
+
+func TestNewConnectClient(t *testing.T) {
+	client, ok := NewConnectClient().(*http.Client)
+	require.True(t, ok)
+	_, ok = client.Transport.(*http2.Transport)
+	assert.True(t, ok)
+}

--- a/api/project_record_extra_test.go
+++ b/api/project_record_extra_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
+	enums "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/enums"
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	openv1alpha1service "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/services"
+	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/internal/constants"
+	"github.com/coscene-io/cocli/internal/name"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestProjectClientCreateProjectUsingTemplate(t *testing.T) {
+	description := "from template"
+	mock := &mockProjectServiceClient{
+		createProjectUsingTemplateFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.CreateProjectUsingTemplateRequest]) (*connect.Response[openv1alpha1resource.Project], error) {
+			assert.Equal(t, "robot-demo", req.Msg.Project.Slug)
+			assert.Equal(t, "Robot Demo", req.Msg.Project.DisplayName)
+			assert.Equal(t, enums.ProjectVisibilityEnum_PRIVATE, req.Msg.Project.Visibility)
+			assert.Equal(t, description, req.Msg.Project.GetDescription())
+			assert.Equal(t, "projects/template", req.Msg.ProjectTemplate)
+			assert.Equal(t, []openv1alpha1service.CreateProjectUsingTemplateRequest_TemplateScope{
+				openv1alpha1service.CreateProjectUsingTemplateRequest_CUSTOM_FIELDS,
+				openv1alpha1service.CreateProjectUsingTemplateRequest_ACTIONS,
+			}, req.Msg.TemplateScopes)
+			return connect.NewResponse(&openv1alpha1resource.Project{Name: "projects/new"}), nil
+		},
+	}
+	client := NewProjectClient(mock, nil)
+
+	project, err := client.CreateProjectUsingTemplate(context.Background(), &CreateProjectUsingTemplateOptions{
+		Slug:            "robot-demo",
+		DisplayName:     "Robot Demo",
+		Visibility:      enums.ProjectVisibilityEnum_PRIVATE,
+		Description:     description,
+		ProjectTemplate: "projects/template",
+		TemplateScopes: []openv1alpha1service.CreateProjectUsingTemplateRequest_TemplateScope{
+			openv1alpha1service.CreateProjectUsingTemplateRequest_CUSTOM_FIELDS,
+			openv1alpha1service.CreateProjectUsingTemplateRequest_ACTIONS,
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "projects/new", project.Name)
+}
+
+func TestProjectClientFileListingVariants(t *testing.T) {
+	proj := &name.Project{ProjectID: "project-a"}
+	file := &openv1alpha1resource.File{Filename: "data.bin"}
+	mock := &mockFileServiceClient{
+		listFilesFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.ListFilesRequest]) (*connect.Response[openv1alpha1service.ListFilesResponse], error) {
+			assert.Equal(t, proj.String(), req.Msg.Parent)
+			switch req.Msg.Filter {
+			case `filename.startsWith("logs/")`:
+				assert.Equal(t, int32(constants.MaxPageSize), req.Msg.PageSize)
+			case `filename.endsWith(".mcap")`:
+				assert.Equal(t, int32(25), req.Msg.PageSize)
+				assert.Equal(t, int32(50), req.Msg.Skip)
+			default:
+				assert.Empty(t, req.Msg.Filter)
+				assert.Equal(t, int32(10), req.Msg.PageSize)
+				assert.Equal(t, int32(20), req.Msg.Skip)
+			}
+			return connect.NewResponse(&openv1alpha1service.ListFilesResponse{Files: []*openv1alpha1resource.File{file}, TotalSize: 1}), nil
+		},
+	}
+	client := NewProjectClient(nil, mock)
+
+	all, err := client.ListAllFilesWithFilter(context.Background(), proj, `filename.startsWith("logs/")`)
+	require.NoError(t, err)
+	assert.Equal(t, []*openv1alpha1resource.File{file}, all)
+
+	page, err := client.ListFilesWithPagination(context.Background(), proj, 10, 20)
+	require.NoError(t, err)
+	assert.Equal(t, []*openv1alpha1resource.File{file}, page)
+
+	filteredPage, err := client.ListFilesWithPaginationAndFilter(context.Background(), proj, 25, 50, `filename.endsWith(".mcap")`)
+	require.NoError(t, err)
+	assert.Equal(t, []*openv1alpha1resource.File{file}, filteredPage)
+}
+
+func TestRecordClientFileListingVariants(t *testing.T) {
+	recordName := &name.Record{ProjectID: "project-a", RecordID: "record-a"}
+	file := &openv1alpha1resource.File{Filename: "data.bin"}
+	mock := &mockFileServiceClient{
+		listFilesFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.ListFilesRequest]) (*connect.Response[openv1alpha1service.ListFilesResponse], error) {
+			assert.Equal(t, recordName.String(), req.Msg.Parent)
+			switch req.Msg.Filter {
+			case `filename.startsWith("logs/")`:
+				assert.Equal(t, int32(constants.MaxPageSize), req.Msg.PageSize)
+			case `filename.endsWith(".mcap")`:
+				assert.Equal(t, int32(25), req.Msg.PageSize)
+				assert.Equal(t, int32(50), req.Msg.Skip)
+			default:
+				assert.Empty(t, req.Msg.Filter)
+				assert.Equal(t, int32(10), req.Msg.PageSize)
+				assert.Equal(t, int32(20), req.Msg.Skip)
+			}
+			return connect.NewResponse(&openv1alpha1service.ListFilesResponse{Files: []*openv1alpha1resource.File{file}, TotalSize: 1}), nil
+		},
+	}
+	client := NewRecordClient(nil, mock, nil, nil)
+
+	all, err := client.ListAllFilesWithFilter(context.Background(), recordName, `filename.startsWith("logs/")`)
+	require.NoError(t, err)
+	assert.Equal(t, []*openv1alpha1resource.File{file}, all)
+
+	page, err := client.ListFilesWithPagination(context.Background(), recordName, 10, 20)
+	require.NoError(t, err)
+	assert.Equal(t, []*openv1alpha1resource.File{file}, page)
+
+	filteredPage, err := client.ListFilesWithPaginationAndFilter(context.Background(), recordName, 25, 50, `filename.endsWith(".mcap")`)
+	require.NoError(t, err)
+	assert.Equal(t, []*openv1alpha1resource.File{file}, filteredPage)
+}
+
+func TestRecordClientListAllMoments(t *testing.T) {
+	triggerTime := time.Date(2026, 5, 4, 1, 2, 3, 0, time.UTC)
+	userNickname := "Alice"
+	event := &openv1alpha1resource.Event{
+		DisplayName:      "Hard brake",
+		Description:      "Brake event",
+		TriggerTime:      timestamppb.New(triggerTime),
+		Duration:         durationpb.New(1500 * time.Millisecond),
+		CustomizedFields: map[string]string{"source": "auto"},
+		CustomFieldValues: []*commons.CustomFieldValue{
+			{
+				Property: &commons.Property{Name: "note", Type: &commons.Property_Text{Text: &commons.TextType{}}},
+				Value:    &commons.CustomFieldValue_Text{Text: &commons.TextValue{Value: "sharp"}},
+			},
+			{
+				Property: &commons.Property{Name: "score", Type: &commons.Property_Number{Number: &commons.NumberType{}}},
+				Value:    &commons.CustomFieldValue_Number{Number: &commons.NumberValue{Value: 7}},
+			},
+			{
+				Property: &commons.Property{Name: "kind", Type: &commons.Property_Enums{Enums: &commons.EnumType{Values: map[string]string{"brake": "Brake"}}}},
+				Value:    &commons.CustomFieldValue_Enums{Enums: &commons.EnumValue{Id: "brake"}},
+			},
+			{
+				Property: &commons.Property{Name: "when", Type: &commons.Property_Time{Time: &commons.TimeType{}}},
+				Value:    &commons.CustomFieldValue_Time{Time: &commons.TimeValue{Value: timestamppb.New(triggerTime)}},
+			},
+			{
+				Property: &commons.Property{Name: "owner", Type: &commons.Property_User{User: &commons.UserType{}}},
+				Value:    &commons.CustomFieldValue_User{User: &commons.UserValue{Ids: []string{"u1"}}},
+			},
+		},
+	}
+	eventCalls := 0
+	recordSvc := &mockRecordServiceClient{
+		listRecordEventsFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.ListRecordEventsRequest]) (*connect.Response[openv1alpha1service.ListRecordEventsResponse], error) {
+			if eventCalls > 0 {
+				return connect.NewResponse(&openv1alpha1service.ListRecordEventsResponse{}), nil
+			}
+			eventCalls++
+			return connect.NewResponse(&openv1alpha1service.ListRecordEventsResponse{Events: []*openv1alpha1resource.Event{event}}), nil
+		},
+	}
+	userSvc := &mockUserServiceClient{
+		batchGetUsersFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.BatchGetUsersRequest]) (*connect.Response[openv1alpha1service.BatchGetUsersResponse], error) {
+			assert.Equal(t, []string{"users/u1"}, req.Msg.Names)
+			return connect.NewResponse(&openv1alpha1service.BatchGetUsersResponse{
+				Users: []*openv1alpha1resource.User{{Name: "users/u1", Nickname: &userNickname}},
+			}), nil
+		},
+	}
+	client := NewRecordClient(recordSvc, nil, userSvc, nil)
+
+	moments, err := client.ListAllMoments(context.Background(), &name.Record{ProjectID: "project-a", RecordID: "record-a"})
+
+	require.NoError(t, err)
+	require.Len(t, moments, 1)
+	assert.Equal(t, "Hard brake", moments[0].Name)
+	assert.Equal(t, "Brake event", moments[0].Description)
+	assert.Equal(t, "1.500000000s", moments[0].Duration)
+	assert.Equal(t, map[string]string{"source": "auto"}, moments[0].Attribute)
+	assert.Contains(t, moments[0].CustomFieldValues, map[string]any{"note": "sharp"})
+	assert.Contains(t, moments[0].CustomFieldValues, map[string]any{"score": float64(7)})
+	assert.Contains(t, moments[0].CustomFieldValues, map[string]any{"kind": "Brake"})
+	assert.Contains(t, moments[0].CustomFieldValues, map[string]any{"owner": []string{"Alice"}})
+}

--- a/api/small_clients_test.go
+++ b/api/small_clients_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"testing"
+
+	openv1alpha1connect "buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go/coscene/openapi/dataplatform/v1alpha1/services/servicesconnect"
+	commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	openv1alpha1service "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/services"
+	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/internal/name"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockContainerRegistryServiceClient struct {
+	openv1alpha1connect.ContainerRegistryServiceClient
+	createBasicCredentialFunc func(context.Context, *connect.Request[openv1alpha1service.CreateBasicCredentialRequest]) (*connect.Response[openv1alpha1service.BasicCredential], error)
+}
+
+func (m *mockContainerRegistryServiceClient) CreateBasicCredential(ctx context.Context, req *connect.Request[openv1alpha1service.CreateBasicCredentialRequest]) (*connect.Response[openv1alpha1service.BasicCredential], error) {
+	return m.createBasicCredentialFunc(ctx, req)
+}
+
+type mockCustomFieldServiceClient struct {
+	openv1alpha1connect.CustomFieldServiceClient
+	getRecordCustomFieldSchemaFunc func(context.Context, *connect.Request[openv1alpha1service.GetRecordCustomFieldSchemaRequest]) (*connect.Response[commons.CustomFieldSchema], error)
+}
+
+func (m *mockCustomFieldServiceClient) GetRecordCustomFieldSchema(ctx context.Context, req *connect.Request[openv1alpha1service.GetRecordCustomFieldSchemaRequest]) (*connect.Response[commons.CustomFieldSchema], error) {
+	return m.getRecordCustomFieldSchemaFunc(ctx, req)
+}
+
+type mockEventServiceClient struct {
+	openv1alpha1connect.EventServiceClient
+	obtainEventFunc func(context.Context, *connect.Request[openv1alpha1service.ObtainEventRequest]) (*connect.Response[openv1alpha1service.ObtainEventResponse], error)
+}
+
+func (m *mockEventServiceClient) ObtainEvent(ctx context.Context, req *connect.Request[openv1alpha1service.ObtainEventRequest]) (*connect.Response[openv1alpha1service.ObtainEventResponse], error) {
+	return m.obtainEventFunc(ctx, req)
+}
+
+type mockOrganizationServiceClient struct {
+	openv1alpha1connect.OrganizationServiceClient
+	getOrganizationFunc func(context.Context, *connect.Request[openv1alpha1service.GetOrganizationRequest]) (*connect.Response[openv1alpha1resource.Organization], error)
+}
+
+func (m *mockOrganizationServiceClient) GetOrganization(ctx context.Context, req *connect.Request[openv1alpha1service.GetOrganizationRequest]) (*connect.Response[openv1alpha1resource.Organization], error) {
+	return m.getOrganizationFunc(ctx, req)
+}
+
+type mockRoleServiceClient struct {
+	openv1alpha1connect.RoleServiceClient
+	listRolesFunc func(context.Context, *connect.Request[openv1alpha1service.ListRolesRequest]) (*connect.Response[openv1alpha1service.ListRolesResponse], error)
+}
+
+func (m *mockRoleServiceClient) ListRoles(ctx context.Context, req *connect.Request[openv1alpha1service.ListRolesRequest]) (*connect.Response[openv1alpha1service.ListRolesResponse], error) {
+	return m.listRolesFunc(ctx, req)
+}
+
+type mockTaskServiceClient struct {
+	openv1alpha1connect.TaskServiceClient
+	upsertTaskFunc func(context.Context, *connect.Request[openv1alpha1service.UpsertTaskRequest]) (*connect.Response[openv1alpha1resource.Task], error)
+	syncTaskFunc   func(context.Context, *connect.Request[openv1alpha1service.SyncTaskRequest]) (*connect.Response[openv1alpha1resource.Task], error)
+}
+
+func (m *mockTaskServiceClient) UpsertTask(ctx context.Context, req *connect.Request[openv1alpha1service.UpsertTaskRequest]) (*connect.Response[openv1alpha1resource.Task], error) {
+	return m.upsertTaskFunc(ctx, req)
+}
+
+func (m *mockTaskServiceClient) SyncTask(ctx context.Context, req *connect.Request[openv1alpha1service.SyncTaskRequest]) (*connect.Response[openv1alpha1resource.Task], error) {
+	return m.syncTaskFunc(ctx, req)
+}
+
+func TestContainerRegistryClientCreateBasicCredential(t *testing.T) {
+	mock := &mockContainerRegistryServiceClient{
+		createBasicCredentialFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.CreateBasicCredentialRequest]) (*connect.Response[openv1alpha1service.BasicCredential], error) {
+			return connect.NewResponse(&openv1alpha1service.BasicCredential{Username: "robot", Password: "secret"}), nil
+		},
+	}
+
+	credential, err := NewContainerRegistryClient(mock).CreateBasicCredential(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, "robot", credential.Username)
+	assert.Equal(t, "secret", credential.Password)
+}
+
+func TestCustomFieldClientGetRecordCustomFieldSchema(t *testing.T) {
+	mock := &mockCustomFieldServiceClient{
+		getRecordCustomFieldSchemaFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.GetRecordCustomFieldSchemaRequest]) (*connect.Response[commons.CustomFieldSchema], error) {
+			assert.Equal(t, "projects/project-a", req.Msg.Project)
+			return connect.NewResponse(&commons.CustomFieldSchema{
+				Properties: []*commons.Property{{Name: "weather"}},
+			}), nil
+		},
+	}
+
+	schema, err := NewCustomFieldClient(mock).GetRecordCustomFieldSchema(context.Background(), &name.Project{ProjectID: "project-a"})
+
+	require.NoError(t, err)
+	require.Len(t, schema.Properties, 1)
+	assert.Equal(t, "weather", schema.Properties[0].Name)
+}
+
+func TestEventClientObtainEvent(t *testing.T) {
+	event := &openv1alpha1resource.Event{DisplayName: "Hard brake"}
+	mock := &mockEventServiceClient{
+		obtainEventFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.ObtainEventRequest]) (*connect.Response[openv1alpha1service.ObtainEventResponse], error) {
+			assert.Equal(t, "projects/project-a", req.Msg.Parent)
+			assert.Equal(t, event, req.Msg.Event)
+			return connect.NewResponse(&openv1alpha1service.ObtainEventResponse{Event: event}), nil
+		},
+	}
+
+	res, err := NewEventClient(mock).ObtainEvent(context.Background(), "projects/project-a", event)
+
+	require.NoError(t, err)
+	assert.Equal(t, event, res.Event)
+}
+
+func TestOrganizationClientSlug(t *testing.T) {
+	mock := &mockOrganizationServiceClient{
+		getOrganizationFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.GetOrganizationRequest]) (*connect.Response[openv1alpha1resource.Organization], error) {
+			assert.Equal(t, "organizations/current", req.Msg.Name)
+			return connect.NewResponse(&openv1alpha1resource.Organization{Slug: "coScene"}), nil
+		},
+	}
+
+	org, err := name.NewOrganization("organizations/current")
+	require.NoError(t, err)
+	slug, err := NewOrganizationClient(mock).Slug(context.Background(), org)
+
+	require.NoError(t, err)
+	assert.Equal(t, "coScene", slug)
+}
+
+func TestRoleClientListRoles(t *testing.T) {
+	mock := &mockRoleServiceClient{
+		listRolesFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.ListRolesRequest]) (*connect.Response[openv1alpha1service.ListRolesResponse], error) {
+			assert.Equal(t, int32(20), req.Msg.PageSize)
+			assert.Equal(t, "next", req.Msg.PageToken)
+			assert.Equal(t, `level="project"`, req.Msg.Filter)
+			return connect.NewResponse(&openv1alpha1service.ListRolesResponse{
+				Roles:         []*openv1alpha1resource.Role{{Name: "roles/admin", Code: "admin"}},
+				NextPageToken: "after",
+				TotalSize:     1,
+			}), nil
+		},
+	}
+
+	res, err := NewRoleClient(mock).ListRoles(context.Background(), &ListRolesOptions{
+		Level:     "project",
+		PageSize:  20,
+		PageToken: "next",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "after", res.NextPageToken)
+	assert.Equal(t, int64(1), res.TotalSize)
+	require.Len(t, res.Roles, 1)
+	assert.Equal(t, "admin", res.Roles[0].Code)
+}
+
+func TestTaskClientUpsertAndSync(t *testing.T) {
+	task := &openv1alpha1resource.Task{Name: "projects/project-a/tasks/task-a", Title: "Review"}
+	mock := &mockTaskServiceClient{
+		upsertTaskFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.UpsertTaskRequest]) (*connect.Response[openv1alpha1resource.Task], error) {
+			assert.Equal(t, "projects/project-a", req.Msg.Parent)
+			assert.Equal(t, task, req.Msg.Task)
+			return connect.NewResponse(task), nil
+		},
+		syncTaskFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.SyncTaskRequest]) (*connect.Response[openv1alpha1resource.Task], error) {
+			assert.Equal(t, "projects/project-a/tasks/task-a", req.Msg.Name)
+			return connect.NewResponse(task), nil
+		},
+	}
+	client := NewTaskClient(mock)
+
+	upserted, err := client.UpsertTask(context.Background(), "projects/project-a", task)
+	require.NoError(t, err)
+	assert.Equal(t, task, upserted)
+
+	synced, err := client.SyncTask(context.Background(), "projects/project-a/tasks/task-a")
+	require.NoError(t, err)
+	assert.Equal(t, task, synced)
+}

--- a/api/user_extra_test.go
+++ b/api/user_extra_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"testing"
+
+	openv1alpha1connect "buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go/coscene/openapi/dataplatform/v1alpha1/services/servicesconnect"
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	openv1alpha1service "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/services"
+	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/internal/name"
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockUserServiceClient struct {
+	openv1alpha1connect.UserServiceClient
+	batchGetUsersFunc func(context.Context, *connect.Request[openv1alpha1service.BatchGetUsersRequest]) (*connect.Response[openv1alpha1service.BatchGetUsersResponse], error)
+	listUsersFunc     func(context.Context, *connect.Request[openv1alpha1service.ListUsersRequest]) (*connect.Response[openv1alpha1service.ListUsersResponse], error)
+	getUserFunc       func(context.Context, *connect.Request[openv1alpha1service.GetUserRequest]) (*connect.Response[openv1alpha1resource.User], error)
+}
+
+func (m *mockUserServiceClient) BatchGetUsers(ctx context.Context, req *connect.Request[openv1alpha1service.BatchGetUsersRequest]) (*connect.Response[openv1alpha1service.BatchGetUsersResponse], error) {
+	if m.batchGetUsersFunc != nil {
+		return m.batchGetUsersFunc(ctx, req)
+	}
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+
+func (m *mockUserServiceClient) ListUsers(ctx context.Context, req *connect.Request[openv1alpha1service.ListUsersRequest]) (*connect.Response[openv1alpha1service.ListUsersResponse], error) {
+	if m.listUsersFunc != nil {
+		return m.listUsersFunc(ctx, req)
+	}
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+
+func (m *mockUserServiceClient) GetUser(ctx context.Context, req *connect.Request[openv1alpha1service.GetUserRequest]) (*connect.Response[openv1alpha1resource.User], error) {
+	if m.getUserFunc != nil {
+		return m.getUserFunc(ctx, req)
+	}
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+
+func TestUserClientBatchGetUsers(t *testing.T) {
+	t.Run("empty set avoids request", func(t *testing.T) {
+		client := NewUserClient(&mockUserServiceClient{})
+		got, err := client.BatchGetUsers(context.Background(), mapset.NewSet[name.User]())
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("maps response by resource name", func(t *testing.T) {
+		nickname := "Alice"
+		mock := &mockUserServiceClient{
+			batchGetUsersFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.BatchGetUsersRequest]) (*connect.Response[openv1alpha1service.BatchGetUsersResponse], error) {
+				assert.ElementsMatch(t, []string{"users/u1"}, req.Msg.Names)
+				return connect.NewResponse(&openv1alpha1service.BatchGetUsersResponse{
+					Users: []*openv1alpha1resource.User{{Name: "users/u1", Nickname: &nickname}},
+				}), nil
+			},
+		}
+		client := NewUserClient(mock)
+
+		got, err := client.BatchGetUsers(context.Background(), mapset.NewSet(name.User{UserID: "u1"}))
+
+		require.NoError(t, err)
+		require.Contains(t, got, "users/u1")
+		assert.Equal(t, "Alice", got["users/u1"].GetNickname())
+	})
+}
+
+func TestUserClientListGetAndFind(t *testing.T) {
+	mock := &mockUserServiceClient{
+		listUsersFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.ListUsersRequest]) (*connect.Response[openv1alpha1service.ListUsersResponse], error) {
+			assert.Equal(t, "organizations/current", req.Msg.Parent)
+			assert.Equal(t, int32(20), req.Msg.PageSize)
+			assert.Equal(t, "next", req.Msg.PageToken)
+			assert.Equal(t, `role.code="admin"`, req.Msg.Filter)
+			return connect.NewResponse(&openv1alpha1service.ListUsersResponse{
+				Users:         []*openv1alpha1resource.User{{Name: "users/u1"}},
+				NextPageToken: "after",
+				TotalSize:     1,
+			}), nil
+		},
+		getUserFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.GetUserRequest]) (*connect.Response[openv1alpha1resource.User], error) {
+			assert.Equal(t, "users/u1", req.Msg.Name)
+			return connect.NewResponse(&openv1alpha1resource.User{Name: "users/u1"}), nil
+		},
+	}
+	client := NewUserClient(mock)
+
+	list, err := client.ListUsers(context.Background(), &ListUsersOptions{
+		Parent:    "organizations/current",
+		PageSize:  20,
+		PageToken: "next",
+		RoleCode:  "admin",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "after", list.NextPageToken)
+	assert.Equal(t, int64(1), list.TotalSize)
+
+	user, err := client.GetUser(context.Background(), "users/u1")
+	require.NoError(t, err)
+	assert.Equal(t, "users/u1", user.Name)
+}
+
+func TestUserClientFindUsersByNicknameKeepsExactMatches(t *testing.T) {
+	alice := "Alice"
+	aliceTeam := "Alice Team"
+	mock := &mockUserServiceClient{
+		listUsersFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.ListUsersRequest]) (*connect.Response[openv1alpha1service.ListUsersResponse], error) {
+			assert.Equal(t, `nickname="Alice"`, req.Msg.Filter)
+			return connect.NewResponse(&openv1alpha1service.ListUsersResponse{
+				Users: []*openv1alpha1resource.User{
+					{Name: "users/u1", Nickname: &alice},
+					{Name: "users/u2", Nickname: &aliceTeam},
+				},
+			}), nil
+		},
+	}
+	client := NewUserClient(mock)
+
+	got, err := client.FindUsersByNickname(context.Background(), "Alice")
+
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "users/u1", got[0].Name)
+}

--- a/internal/apimocks/mock_profile_manager_test.go
+++ b/internal/apimocks/mock_profile_manager_test.go
@@ -64,7 +64,7 @@ func TestMockProvider(t *testing.T) {
 	assert.Equal(t, provider.ProfileManager().ProfileManager, pm)
 
 	custom := NewMockProfileManager(t)
-	custom.ProfileManager.CurrentProfile = "custom"
+	custom.CurrentProfile = "custom"
 	provider.SetProfileManager(custom)
 	pm, err = provider.GetProfileManager()
 	require.NoError(t, err)

--- a/internal/apimocks/mock_profile_manager_test.go
+++ b/internal/apimocks/mock_profile_manager_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apimocks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/name"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockProfileManager(t *testing.T) {
+	pm := NewMockProfileManager(t)
+
+	assert.True(t, pm.CheckAuth())
+	require.NoError(t, pm.Auth(context.Background()))
+	assert.Nil(t, pm.RecordCli())
+	assert.Nil(t, pm.FileCli())
+	assert.Nil(t, pm.LabelCli())
+	assert.Nil(t, pm.ProjectCli())
+	assert.Nil(t, pm.ActionCli())
+	assert.Nil(t, pm.TaskCli())
+	assert.Nil(t, pm.EventCli())
+	assert.Nil(t, pm.CustomFieldCli())
+
+	project, err := pm.ProjectName(context.Background(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "test-project", project.ProjectID)
+
+	project, err = pm.ProjectName(context.Background(), "override-project")
+	require.NoError(t, err)
+	assert.Equal(t, "override-project", project.ProjectID)
+
+	recordURL, err := pm.GetRecordUrl(context.Background(), &name.Record{ProjectID: "p", RecordID: "r"})
+	require.NoError(t, err)
+	assert.Equal(t, "https://openapi.mock.coscene.com/records/r", recordURL)
+
+	projectURL, err := pm.GetProjectUrl(context.Background(), &name.Project{ProjectID: "p"})
+	require.NoError(t, err)
+	assert.Equal(t, "https://openapi.mock.coscene.com/projects/p", projectURL)
+}
+
+func TestMockProvider(t *testing.T) {
+	provider := NewMockProvider(t)
+
+	pm, err := provider.GetProfileManager()
+	require.NoError(t, err)
+	assert.Equal(t, "test-profile", pm.CurrentProfile)
+	assert.Equal(t, provider.ProfileManager().ProfileManager, pm)
+
+	custom := NewMockProfileManager(t)
+	custom.ProfileManager.CurrentProfile = "custom"
+	provider.SetProfileManager(custom)
+	pm, err = provider.GetProfileManager()
+	require.NoError(t, err)
+	assert.Equal(t, "custom", pm.CurrentProfile)
+
+	require.NoError(t, provider.Persist(&config.ProfileManager{}))
+}

--- a/internal/config/profile_extra_test.go
+++ b/internal/config/profile_extra_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"github.com/coscene-io/cocli/api"
+	"github.com/coscene-io/cocli/internal/name"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProfileDisplayAndURLs(t *testing.T) {
+	profile := &Profile{
+		Name:        "dev",
+		EndPoint:    "https://openapi.coscene.cn",
+		Org:         "org-a",
+		ProjectSlug: "project-a",
+		ProjectName: "projects/project-a",
+	}
+
+	assert.Equal(t, "dev (*)", profile.StringWithOpts(true, false))
+	verbose := profile.StringWithOpts(false, true)
+	assert.Contains(t, verbose, "Profile Name:")
+	assert.Contains(t, verbose, "Endpoint:")
+	assert.True(t, profile.CheckAuth())
+	assert.Equal(t, "https://coscene.cn", profile.GetBaseUrl())
+
+	profile.EndPoint = "https://openapi.api.coscene.dev"
+	assert.Equal(t, "https://home.coscene.dev", profile.GetBaseUrl())
+}
+
+func TestProfileAuthAndURLsWithInjectedClients(t *testing.T) {
+	profile := &Profile{
+		Name:        "dev",
+		EndPoint:    "https://openapi.coscene.cn",
+		Token:       "token",
+		ProjectSlug: "project-a",
+	}
+	profile.cliOnce.Do(func() {})
+	profile.orgcli = fakeOrgClient{slug: "org-a"}
+	profile.projcli = fakeProjectClient{project: &openv1alpha1resource.Project{
+		Name: "projects/project-a",
+		Slug: "project-a",
+	}}
+
+	require.NoError(t, profile.Auth(context.Background()))
+	assert.Equal(t, "org-a", profile.Org)
+	assert.Equal(t, "projects/project-a", profile.ProjectName)
+
+	recordURL, err := profile.GetRecordUrl(context.Background(), &name.Record{ProjectID: "project-a", RecordID: "record-a"})
+	require.NoError(t, err)
+	assert.Equal(t, "https://coscene.cn/org-a/project-a/records/record-a", recordURL)
+
+	projectURL, err := profile.GetProjectUrl(context.Background(), &name.Project{ProjectID: "project-a"})
+	require.NoError(t, err)
+	assert.Equal(t, "https://coscene.cn/org-a/project-a", projectURL)
+
+	var nilProfile *Profile
+	assert.NoError(t, nilProfile.Auth(context.Background()))
+}
+
+func TestProfileClientAccessorsInitializeClients(t *testing.T) {
+	profile := &Profile{
+		Name:        "dev",
+		EndPoint:    "https://openapi.coscene.cn",
+		Token:       "token",
+		ProjectSlug: "project-a",
+	}
+
+	assert.NotNil(t, profile.OrgCli())
+	assert.NotNil(t, profile.ProjectCli())
+	assert.NotNil(t, profile.RecordCli())
+	assert.NotNil(t, profile.LabelCli())
+	assert.NotNil(t, profile.UserCli())
+	assert.NotNil(t, profile.FileCli())
+	assert.NotNil(t, profile.ActionCli())
+	assert.NotNil(t, profile.SecurityTokenCli())
+	assert.NotNil(t, profile.EventCli())
+	assert.NotNil(t, profile.TaskCli())
+	assert.NotNil(t, profile.ContainerRegistryCli())
+	assert.NotNil(t, profile.FileSystemCli())
+	assert.NotNil(t, profile.RoleCli())
+	assert.NotNil(t, profile.CustomFieldCli())
+}
+
+func TestGlobalConfigGetProfileManagerFromYaml(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+current-profile: dev
+profiles:
+  - name: dev
+    endpoint: https://openapi.dev.coscene.cn
+    token: token-a
+    project: project-a
+`), 0644))
+
+	pm, err := Provide(cfgPath).GetProfileManager()
+
+	require.NoError(t, err)
+	assert.Equal(t, "dev", pm.CurrentProfile)
+	require.Len(t, pm.Profiles, 1)
+	assert.Equal(t, "project-a", pm.Profiles[0].ProjectSlug)
+}
+
+func TestGlobalConfigGetProfileManagerFromEnv(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`{}`), 0644))
+	t.Setenv("COS_ENDPOINT", "https://openapi.dev.coscene.cn")
+	t.Setenv("COS_TOKEN", "token-a")
+	t.Setenv("COS_PROJECT", "project-a")
+	t.Setenv("COS_PROJECTID", "project-id-a")
+
+	pm, err := Provide(cfgPath).GetProfileManager()
+
+	require.NoError(t, err)
+	assert.Equal(t, "ENV_LOADED_PROFILE", pm.CurrentProfile)
+	require.Len(t, pm.Profiles, 1)
+	assert.Equal(t, "projects/project-id-a", pm.Profiles[0].ProjectName)
+}
+
+func TestGlobalConfigPersist(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+current-profile: old
+profiles:
+  - name: old
+    endpoint: https://openapi.dev.coscene.cn
+    token: old-token
+    project: old-project
+`), 0644))
+
+	pm := &ProfileManager{
+		CurrentProfile: "new",
+		Profiles: []*Profile{
+			{Name: "new", EndPoint: "https://openapi.dev.coscene.cn", Token: "new-token", ProjectSlug: "new-project"},
+		},
+	}
+	require.NoError(t, Provide(cfgPath).Persist(pm))
+
+	reloaded, err := Provide(cfgPath).GetProfileManager()
+	require.NoError(t, err)
+	assert.Equal(t, "new", reloaded.CurrentProfile)
+	require.Len(t, reloaded.Profiles, 1)
+	assert.Equal(t, "new-project", reloaded.Profiles[0].ProjectSlug)
+}
+
+type fakeOrgClient struct {
+	slug string
+}
+
+func (f fakeOrgClient) Slug(ctx context.Context, org *name.Organization) (string, error) {
+	return f.slug, nil
+}
+
+type fakeProjectClient struct {
+	api.ProjectInterface
+	project *openv1alpha1resource.Project
+}
+
+func (f fakeProjectClient) Name(ctx context.Context, projectSlug string) (*name.Project, error) {
+	return name.NewProject(f.project.Name)
+}
+
+func (f fakeProjectClient) Get(ctx context.Context, projectName *name.Project) (*openv1alpha1resource.Project, error) {
+	return f.project, nil
+}

--- a/internal/config/profile_manager_extra_test.go
+++ b/internal/config/profile_manager_extra_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"testing"
+
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProfileManagerAccessors(t *testing.T) {
+	pm := &ProfileManager{
+		CurrentProfile: "dev",
+		Profiles: []*Profile{
+			{
+				Name:        "dev",
+				EndPoint:    "https://openapi.coscene.cn",
+				Token:       "token",
+				Org:         "org-a",
+				ProjectSlug: "project-a",
+				ProjectName: "projects/project-a",
+			},
+		},
+	}
+
+	assert.False(t, pm.IsEmpty())
+	assert.True(t, pm.CheckAuth())
+	assert.Equal(t, "https://coscene.cn", pm.GetBaseUrl())
+	assert.Equal(t, pm.Profiles[0], pm.GetCurrentProfile())
+	assert.Equal(t, pm.Profiles, pm.GetProfiles())
+
+	project, err := pm.ProjectName(context.Background(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "project-a", project.ProjectID)
+}
+
+func TestProfileManagerProjectNameRejectsInvalidCurrentProject(t *testing.T) {
+	pm := &ProfileManager{
+		CurrentProfile: "dev",
+		Profiles: []*Profile{
+			{Name: "dev", EndPoint: "https://openapi.coscene.cn", Token: "token", ProjectSlug: "project-a", ProjectName: "bad"},
+		},
+	}
+
+	_, err := pm.ProjectName(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "new project name")
+}
+
+func TestProfileManagerDeleteProfile(t *testing.T) {
+	pm := &ProfileManager{
+		CurrentProfile: "dev",
+		Profiles: []*Profile{
+			{Name: "dev", EndPoint: "https://openapi.coscene.cn", Token: "token", ProjectSlug: "dev-project"},
+			{Name: "prod", EndPoint: "https://openapi.coscene.cn", Token: "token", ProjectSlug: "prod-project"},
+		},
+	}
+
+	require.NoError(t, pm.DeleteProfile("dev"))
+	assert.Equal(t, "prod", pm.CurrentProfile)
+	require.Len(t, pm.Profiles, 1)
+	assert.Equal(t, "prod", pm.Profiles[0].Name)
+
+	err := pm.DeleteProfile("missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "profile missing not found")
+}
+
+func TestProfileManagerMutationsWithInjectedClients(t *testing.T) {
+	t.Run("AddProfile authenticates first profile", func(t *testing.T) {
+		pm := &ProfileManager{}
+		require.NoError(t, pm.AddProfile(testProfileWithClients("dev", "project-a")))
+		assert.Equal(t, "dev", pm.CurrentProfile)
+		require.Len(t, pm.Profiles, 1)
+		assert.Equal(t, "org-a", pm.Profiles[0].Org)
+		assert.Equal(t, "projects/project-a", pm.Profiles[0].ProjectName)
+	})
+
+	t.Run("SetProfile updates current profile and refreshes auth fields", func(t *testing.T) {
+		pm := &ProfileManager{
+			CurrentProfile: "dev",
+			Profiles:       []*Profile{testProfileWithClients("dev", "old-project")},
+		}
+		require.NoError(t, pm.SetProfile(&Profile{
+			Name:        "dev",
+			EndPoint:    "https://openapi.coscene.cn",
+			Token:       "new-token",
+			ProjectSlug: "project-a",
+		}))
+		assert.Equal(t, "dev", pm.CurrentProfile)
+		assert.Equal(t, "new-token", pm.Profiles[0].Token)
+		assert.Equal(t, "projects/old-project", pm.Profiles[0].ProjectName)
+	})
+
+	t.Run("SwitchProfile moves current profile", func(t *testing.T) {
+		pm := &ProfileManager{
+			CurrentProfile: "dev",
+			Profiles: []*Profile{
+				testProfileWithClients("dev", "project-a"),
+				testProfileWithClients("prod", "project-b"),
+			},
+		}
+		require.NoError(t, pm.SwitchProfile("prod"))
+		assert.Equal(t, "prod", pm.CurrentProfile)
+		assert.Equal(t, "projects/project-b", pm.GetCurrentProfile().ProjectName)
+
+		err := pm.SwitchProfile("missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Invalid profile name")
+	})
+}
+
+func testProfileWithClients(profileName string, projectID string) *Profile {
+	profile := &Profile{
+		Name:        profileName,
+		EndPoint:    "https://openapi.coscene.cn",
+		Token:       "token",
+		ProjectSlug: projectID,
+	}
+	profile.cliOnce.Do(func() {})
+	profile.orgcli = fakeOrgClient{slug: "org-a"}
+	profile.projcli = fakeProjectClient{project: &openv1alpha1resource.Project{
+		Name: "projects/" + projectID,
+		Slug: projectID,
+	}}
+	return profile
+}

--- a/internal/iostreams/iostreams_test.go
+++ b/internal/iostreams/iostreams_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iostreams
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemReturnsStandardStreams(t *testing.T) {
+	io := System()
+	require.NotNil(t, io.In)
+	require.NotNil(t, io.Out)
+	require.NotNil(t, io.ErrOut)
+}
+
+func TestIOStreamsPrintHelpers(t *testing.T) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	io := Test(nil, &out, &errOut)
+
+	io.Println("hello")
+	io.Printf("%s", "world")
+	io.Eprintln("bad")
+	io.Eprintf("%s", "news")
+
+	assert.Equal(t, "hello\nworld", out.String())
+	assert.Equal(t, "bad\nnews", errOut.String())
+}

--- a/internal/printer/interface.go
+++ b/internal/printer/interface.go
@@ -32,6 +32,9 @@ type Options struct {
 }
 
 func Printer(format string, opts *Options) (Interface, error) {
+	if opts == nil {
+		opts = &Options{}
+	}
 	tableOpts := opts.TableOpts
 	if tableOpts == nil {
 		tableOpts = &table.PrintOpts{}

--- a/internal/printer/printable/more_resources_test.go
+++ b/internal/printer/printable/more_resources_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package printable
+
+import (
+	"testing"
+	"time"
+
+	commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
+	enums "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/enums"
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	openv1alpha1service "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/services"
+	"github.com/coscene-io/cocli/internal/printer/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestActionPrintable(t *testing.T) {
+	now := timestamppb.New(time.Date(2026, 5, 4, 1, 0, 0, 0, time.UTC))
+	actions := []*openv1alpha1resource.Action{
+		{
+			Name:       "projects/project-a/actions/action-a",
+			Spec:       &commons.ActionSpec{Name: "Custom Action"},
+			Author:     "users/alice",
+			UpdateTime: now,
+		},
+		{
+			Name:       "wftmpls/system-a",
+			Spec:       &commons.ActionSpec{Name: "System Action"},
+			Author:     "users/system",
+			UpdateTime: now,
+		},
+	}
+
+	obj := NewAction(actions)
+	msg := obj.ToProtoMessage().(*openv1alpha1service.ListActionsResponse)
+	assert.Equal(t, int64(2), msg.TotalSize)
+
+	tbl := obj.ToTable(&table.PrintOpts{})
+	require.Len(t, tbl.Rows, 2)
+	assert.Equal(t, "action-a", tbl.Rows[0][0])
+	assert.Equal(t, "custom", tbl.Rows[0][1])
+	assert.Equal(t, "system-a", tbl.Rows[1][0])
+	assert.Equal(t, "system", tbl.Rows[1][1])
+
+	verbose := obj.ToTable(&table.PrintOpts{Verbose: true})
+	assert.Equal(t, "projects/project-a/actions/action-a", verbose.Rows[0][0])
+}
+
+func TestActionRunPrintable(t *testing.T) {
+	now := timestamppb.New(time.Date(2026, 5, 4, 1, 0, 0, 0, time.UTC))
+	action := &openv1alpha1resource.Action{Spec: &commons.ActionSpec{Name: "Build"}}
+	runs := []*openv1alpha1resource.ActionRun{
+		{
+			Name:       "projects/project-a/actionRuns/run-a",
+			CreateTime: now,
+			Action:     action,
+			State:      enums.ActionRunStateEnum_RUNNING,
+			Creator:    &openv1alpha1resource.ActionRun_User{User: "users/alice"},
+		},
+		{
+			Name:       "projects/project-a/actionRuns/run-b",
+			CreateTime: now,
+			Action:     action,
+			State:      enums.ActionRunStateEnum_SUCCEEDED,
+			Creator: &openv1alpha1resource.ActionRun_Trigger{
+				Trigger: &openv1alpha1resource.Trigger{Spec: &commons.TriggerSpec{Name: "Nightly"}},
+			},
+		},
+	}
+
+	obj := NewActionRun(runs)
+	msg := obj.ToProtoMessage().(*openv1alpha1service.ListActionRunsResponse)
+	assert.Equal(t, int64(2), msg.TotalSize)
+
+	tbl := obj.ToTable(&table.PrintOpts{})
+	require.Len(t, tbl.Rows, 2)
+	assert.Equal(t, "run-a", tbl.Rows[0][0])
+	assert.Equal(t, "RUNNING", tbl.Rows[0][1])
+	assert.Equal(t, "Build", tbl.Rows[0][2])
+	assert.Equal(t, "users/alice", tbl.Rows[0][4])
+	assert.Equal(t, "trigger: Nightly", tbl.Rows[1][4])
+}
+
+func TestFilePrintable(t *testing.T) {
+	now := timestamppb.New(time.Date(2026, 5, 4, 1, 0, 0, 0, time.UTC))
+	files := []*openv1alpha1resource.File{
+		{Filename: "data.bin", Size: 2048, CreateTime: now, UpdateTime: now},
+		{Filename: "folder/", Size: 2048, CreateTime: now, UpdateTime: now},
+	}
+
+	obj := NewFile(files)
+	msg := obj.ToProtoMessage().(*openv1alpha1service.ListFilesResponse)
+	assert.Equal(t, int64(2), msg.TotalSize)
+
+	tbl := obj.ToTable(&table.PrintOpts{})
+	require.Len(t, tbl.Rows, 2)
+	assert.Equal(t, "data.bin", tbl.Rows[0][0])
+	assert.Equal(t, "2.00 KB", tbl.Rows[0][1])
+	assert.Equal(t, "-", tbl.Rows[1][1])
+}
+
+func TestEventPrintable(t *testing.T) {
+	now := timestamppb.New(time.Date(2026, 5, 4, 1, 0, 0, 0, time.UTC))
+	events := []*openv1alpha1resource.Event{
+		{
+			DisplayName: "Hard brake",
+			TriggerTime: now,
+			Duration:    durationpb.New(90 * time.Second),
+		},
+	}
+
+	obj := NewEvent(events)
+	msg := obj.ToProtoMessage().(*openv1alpha1service.ListRecordEventsResponse)
+	assert.Equal(t, int64(1), msg.TotalSize)
+
+	tbl := obj.ToTable(&table.PrintOpts{})
+	require.Len(t, tbl.Rows, 1)
+	assert.Equal(t, "Hard brake", tbl.Rows[0][0])
+	assert.Equal(t, "1m30s", tbl.Rows[0][2])
+}
+
+func TestRecordWithMetadataPrintable(t *testing.T) {
+	now := timestamppb.New(time.Date(2026, 5, 4, 1, 0, 0, 0, time.UTC))
+	record := &openv1alpha1resource.Record{
+		Name:        "projects/project-a/records/record-a",
+		Title:       "Road test",
+		Description: "Downtown loop",
+		Device:      &openv1alpha1resource.Device{SerialNumber: "SN-001"},
+		Labels:      []*openv1alpha1resource.Label{{DisplayName: "city"}},
+		Creator:     "users/alice",
+		ByteSize:    2048,
+		FileSize:    3,
+		Summary:     &openv1alpha1resource.RecordSummary{FilesDuration: 10, PlayDuration: 8},
+		CreateTime:  now,
+		UpdateTime:  now,
+		CustomFieldValues: []*commons.CustomFieldValue{
+			{
+				Property: &commons.Property{Name: "weather", Type: &commons.Property_Text{Text: &commons.TextType{}}},
+				Value:    &commons.CustomFieldValue_Text{Text: &commons.TextValue{Value: "sunny"}},
+			},
+		},
+	}
+
+	obj := NewRecordWithMetadata(record, "https://home.coscene.cn/org/project/records/record-a")
+	msg := obj.ToProtoMessage().(*structpb.Struct)
+	assert.Equal(t, "https://home.coscene.cn/org/project/records/record-a", msg.Fields["url"].GetStringValue())
+
+	tbl := obj.ToTable(&table.PrintOpts{})
+	rows := map[string]string{}
+	for _, row := range tbl.Rows {
+		rows[row[0]] = row[1]
+	}
+
+	assert.Equal(t, "record-a", rows["ID:"])
+	assert.Equal(t, "Road test", rows["Title:"])
+	assert.Equal(t, "SN-001", rows["Device:"])
+	assert.Equal(t, "city", rows["Labels:"])
+	assert.Contains(t, rows["Custom Field Values:"], "weather")
+	assert.Equal(t, "2.00 KB", rows["Byte Size:"])
+	assert.Equal(t, "3", rows["File Count:"])
+	assert.Equal(t, "https://home.coscene.cn/org/project/records/record-a", rows["URL:"])
+}
+
+func TestRecordWithMetadataNilRecord(t *testing.T) {
+	obj := NewRecordWithMetadata(nil, "https://example.com/record")
+
+	msg := obj.ToProtoMessage().(*structpb.Struct)
+	assert.Empty(t, msg.Fields)
+
+	tbl := obj.ToTable(&table.PrintOpts{})
+	require.Equal(t, [][]string{{"URL:", "https://example.com/record"}}, tbl.Rows)
+}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package printer
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/coscene-io/cocli/internal/printer/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type testPrintable struct {
+	table table.Table
+}
+
+func (p testPrintable) ToProtoMessage() proto.Message {
+	msg, _ := structpb.NewStruct(map[string]any{
+		"name": "demo",
+		"size": float64(42),
+	})
+	return msg
+}
+
+func (p testPrintable) ToTable(*table.PrintOpts) table.Table {
+	return p.table
+}
+
+func TestPrinterFactory(t *testing.T) {
+	tests := []struct {
+		format string
+		want   any
+	}{
+		{"", &TablePrinter{}},
+		{"table", &TablePrinter{}},
+		{"json", &JSONPrinter{}},
+		{"yaml", &YAMLPrinter{}},
+		{"csv", &CSVPrinter{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.format, func(t *testing.T) {
+			p, err := Printer(tt.format, nil)
+			require.NoError(t, err)
+			assert.IsType(t, tt.want, p)
+		})
+	}
+}
+
+func TestJSONPrinter_PrintObj(t *testing.T) {
+	var buf bytes.Buffer
+	err := (&JSONPrinter{}).PrintObj(testPrintable{}, &buf)
+
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), `"name": "demo"`)
+	assert.True(t, bytes.HasSuffix(buf.Bytes(), []byte("\n")))
+}
+
+func TestYAMLPrinter_PrintObj(t *testing.T) {
+	var buf bytes.Buffer
+	err := (&YAMLPrinter{}).PrintObj(testPrintable{}, &buf)
+
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "name: demo")
+	assert.Contains(t, buf.String(), "size: 42")
+}
+
+func TestTablePrinter_PrintObj(t *testing.T) {
+	obj := testPrintable{table: table.Table{
+		ColumnDefs: []table.ColumnDefinition{
+			{FieldName: "NAME", TrimSize: 8},
+			{FieldName: "DESCRIPTION", TrimSize: 10},
+		},
+		Rows: [][]string{{"alpha", "abcdefghijklmnopqrstuvwxyz"}},
+	}}
+
+	var buf bytes.Buffer
+	err := (&TablePrinter{Opts: &table.PrintOpts{}}).PrintObj(obj, &buf)
+
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "alpha")
+	assert.Contains(t, out, "abcdefg...")
+	assert.NotContains(t, out, "abcdefghijklmnopqrstuvwxyz")
+}
+
+func TestTablePrinter_PrintObjReturnsWriterError(t *testing.T) {
+	obj := testPrintable{table: table.Table{
+		ColumnDefs: []table.ColumnDefinition{{FieldName: "NAME", TrimSize: 8}},
+	}}
+
+	err := (&TablePrinter{Opts: &table.PrintOpts{}}).PrintObj(obj, errWriter{})
+	require.Error(t, err)
+}
+
+func TestGetColumnFormat(t *testing.T) {
+	assert.Equal(t, "%s ", getColumnFormat(true, 10, "anything"))
+	assert.Equal(t, "%-15s", getColumnFormat(false, 10, "abc"))
+}
+
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -16,6 +16,7 @@ package printer
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -68,7 +69,10 @@ func TestJSONPrinter_PrintObj(t *testing.T) {
 	err := (&JSONPrinter{}).PrintObj(testPrintable{}, &buf)
 
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), `"name": "demo"`)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, "demo", got["name"])
+	assert.Equal(t, float64(42), got["size"])
 	assert.True(t, bytes.HasSuffix(buf.Bytes(), []byte("\n")))
 }
 

--- a/internal/printer/table/table_test.go
+++ b/internal/printer/table/table_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestColumnDefinitionFull_ToColumnDefinition(t *testing.T) {
+	fieldName := func(opts *PrintOpts) string {
+		if opts.Wide {
+			return "WIDE"
+		}
+		return "NARROW"
+	}
+
+	full := ColumnDefinitionFull[string]{
+		FieldName:     "fallback",
+		FieldNameFunc: fieldName,
+		TrimSize:      12,
+	}
+
+	got := full.ToColumnDefinition()
+	assert.Equal(t, "fallback", got.FieldName)
+	assert.Equal(t, 12, got.TrimSize)
+	assert.Equal(t, "WIDE", got.FieldNameFunc(&PrintOpts{Wide: true}))
+}
+
+func TestColumnDefs2Table(t *testing.T) {
+	type row struct {
+		Name string
+		Age  int
+	}
+
+	defs := []ColumnDefinitionFull[row]{
+		{
+			FieldName: "NAME",
+			FieldValueFunc: func(r row, opts *PrintOpts) string {
+				return r.Name
+			},
+			TrimSize: 8,
+		},
+		{
+			FieldNameFunc: func(opts *PrintOpts) string {
+				if opts.Wide {
+					return "AGE"
+				}
+				return "YEARS"
+			},
+			FieldValueFunc: func(r row, opts *PrintOpts) string {
+				return strconv.Itoa(r.Age)
+			},
+			TrimSize: 3,
+		},
+	}
+
+	tbl := ColumnDefs2Table(defs, []row{{Name: "Ada", Age: 37}}, &PrintOpts{})
+	require.Len(t, tbl.ColumnDefs, 2)
+	assert.Equal(t, "NAME", tbl.ColumnDefs[0].FieldName)
+	assert.Equal(t, "YEARS", tbl.ColumnDefs[1].FieldNameFunc(&PrintOpts{}))
+	assert.Equal(t, [][]string{{"Ada", "37"}}, tbl.Rows)
+
+	wideWithoutAge := ColumnDefs2Table(defs, []row{{Name: "Ada", Age: 37}}, &PrintOpts{
+		Wide:       true,
+		OmitFields: []string{"AGE"},
+	})
+	require.Len(t, wideWithoutAge.ColumnDefs, 1)
+	assert.Equal(t, [][]string{{"Ada"}}, wideWithoutAge.Rows)
+}

--- a/internal/printer/utils/custom_field_values_test.go
+++ b/internal/printer/utils/custom_field_values_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+	"time"
+
+	commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestGetCustomFieldStructs(t *testing.T) {
+	ts := time.Date(2026, 5, 4, 1, 2, 3, 0, time.UTC)
+	values := []*commons.CustomFieldValue{
+		{
+			Property: &commons.Property{Name: "note", Type: &commons.Property_Text{Text: &commons.TextType{}}},
+			Value:    &commons.CustomFieldValue_Text{Text: &commons.TextValue{Value: "hello"}},
+		},
+		{
+			Property: &commons.Property{Name: "score", Type: &commons.Property_Number{Number: &commons.NumberType{}}},
+			Value:    &commons.CustomFieldValue_Number{Number: &commons.NumberValue{Value: 9.5}},
+		},
+		{
+			Property: &commons.Property{Name: "status", Type: &commons.Property_Enums{Enums: &commons.EnumType{Values: map[string]string{"ok": "OK"}}}},
+			Value:    &commons.CustomFieldValue_Enums{Enums: &commons.EnumValue{Id: "missing"}},
+		},
+		{
+			Property: &commons.Property{Name: "tags", Type: &commons.Property_Enums{Enums: &commons.EnumType{Multiple: true, Values: map[string]string{"a": "Alpha"}}}},
+			Value:    &commons.CustomFieldValue_Enums{Enums: &commons.EnumValue{Ids: []string{"a", "b"}}},
+		},
+		{
+			Property: &commons.Property{Name: "when", Type: &commons.Property_Time{Time: &commons.TimeType{}}},
+			Value:    &commons.CustomFieldValue_Time{Time: &commons.TimeValue{Value: timestamppb.New(ts)}},
+		},
+		{
+			Property: &commons.Property{Name: "owners", Type: &commons.Property_User{User: &commons.UserType{}}},
+			Value:    &commons.CustomFieldValue_User{User: &commons.UserValue{Ids: []string{"u1", "u2"}}},
+		},
+	}
+
+	got := GetCustomFieldStructs(values)
+
+	require.Len(t, got, 6)
+	assert.Equal(t, map[string]any{"property": "note", "value": "hello"}, got[0].AsInterface())
+	assert.Equal(t, map[string]any{"property": "score", "value": float64(9.5)}, got[1].AsInterface())
+	assert.Equal(t, map[string]any{"property": "status", "value": "missing"}, got[2].AsInterface())
+	assert.Equal(t, map[string]any{"property": "tags", "value": "Alpha, b"}, got[3].AsInterface())
+	assert.Equal(t, map[string]any{"property": "when", "value": ts.Format(time.RFC3339)}, got[4].AsInterface())
+	assert.Equal(t, map[string]any{"property": "owners", "value": "u1, u2"}, got[5].AsInterface())
+}
+
+func TestGetCustomFieldStructUnknownType(t *testing.T) {
+	_, err := getCustomFieldStruct(&commons.CustomFieldValue{
+		Property: &commons.Property{Name: "unknown"},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown custom field type")
+}

--- a/internal/prompts/models_test.go
+++ b/internal/prompts/models_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prompts
+
+import (
+	"bytes"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectModel(t *testing.T) {
+	model := selectModel{prompt: "Pick one", items: []string{"first", "second"}, chosen: -1}
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model = updated.(selectModel)
+	require.Nil(t, cmd)
+	assert.Equal(t, 1, model.cursor)
+	assert.Contains(t, model.View(), "> second")
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(selectModel)
+	assert.Equal(t, 1, model.chosen)
+	assert.NotNil(t, cmd)
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	model = updated.(selectModel)
+	assert.True(t, model.quit)
+	assert.NotNil(t, cmd)
+}
+
+func TestStringModel(t *testing.T) {
+	var out bytes.Buffer
+	model := stringModel{
+		promptMsg:    "Name",
+		defaultValue: "default",
+		windowWidth:  80,
+		io:           iostreams.Test(nil, &out, &out),
+	}
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("yz")})
+	model = updated.(stringModel)
+	require.Nil(t, cmd)
+	assert.Equal(t, "yz", model.enteredString)
+	assert.Contains(t, model.View(), "yz")
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	model = updated.(stringModel)
+	assert.Equal(t, "y", model.enteredString)
+
+	model.enteredString = ""
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(stringModel)
+	assert.Equal(t, "default", model.enteredString)
+	assert.NotNil(t, cmd)
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	model = updated.(stringModel)
+	assert.True(t, model.quit)
+	assert.NotNil(t, cmd)
+	assert.Contains(t, out.String(), "Quitting")
+}
+
+func TestYNModel(t *testing.T) {
+	var out bytes.Buffer
+	model := ynModel{promptMsg: "Continue", windowWidth: 80, io: iostreams.Test(nil, &out, &out)}
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	model = updated.(ynModel)
+	assert.True(t, model.confirmed)
+	assert.Equal(t, "y", model.enteredKey)
+	assert.NotNil(t, cmd)
+	assert.Contains(t, model.View(), "Continue")
+
+	model = ynModel{promptMsg: "Continue", windowWidth: 80, io: iostreams.Test(nil, &out, &out)}
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	model = updated.(ynModel)
+	assert.False(t, model.confirmed)
+	assert.Equal(t, "n", model.enteredKey)
+	assert.NotNil(t, cmd)
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	model = updated.(ynModel)
+	assert.True(t, model.quit)
+	assert.NotNil(t, cmd)
+}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTempFileHelpers(t *testing.T) {
+	dir := TempDir(t)
+	src := CreateTempFile(t, dir, "src-*.txt", []byte("hello"))
+	dst := filepath.Join(dir, "dst.txt")
+
+	CopyFile(t, src, dst)
+	AssertFileContent(t, dst, []byte("hello"))
+}
+
+func TestCreateTestFileTree(t *testing.T) {
+	dir := TempDir(t)
+
+	CreateTestFileTree(t, dir, map[string][]byte{
+		"a.txt":        []byte("a"),
+		"nested/b.txt": []byte("b"),
+	})
+
+	AssertFileContent(t, filepath.Join(dir, "a.txt"), []byte("a"))
+	AssertFileContent(t, filepath.Join(dir, "nested", "b.txt"), []byte("b"))
+}
+
+func TestCaptureOutput(t *testing.T) {
+	stdout, stderr := CaptureOutput(t, func() {
+		fmt.Fprint(os.Stdout, "out")
+		fmt.Fprint(os.Stderr, "err")
+	})
+
+	assert.Equal(t, "out", stdout)
+	assert.Equal(t, "err", stderr)
+}
+
+func TestBuilders(t *testing.T) {
+	record := NewRecordBuilder().
+		WithName("projects/p/records/r").
+		WithTitle("title").
+		WithDescription("desc").
+		WithLabels([]*openv1alpha1resource.Label{CreateTestLabel("road")}).
+		WithDevice("devices/d").
+		Build()
+	assert.Equal(t, "projects/p/records/r", record.Name)
+	assert.Equal(t, "title", record.Title)
+	assert.Equal(t, "devices/d", record.Device.Name)
+	require.Len(t, record.Labels, 1)
+
+	file := NewFileBuilder().
+		WithName("projects/p/records/r/files/f.txt").
+		WithFilename("f.txt").
+		WithSize(7).
+		WithSha256("sha").
+		Build()
+	assert.Equal(t, int64(7), file.Size)
+	assert.Equal(t, "sha", file.Sha256)
+
+	project := NewProjectBuilder().
+		WithName("projects/p").
+		WithDisplayName("Project").
+		Build()
+	assert.Equal(t, "Project", project.DisplayName)
+
+	label := CreateTestLabel("city")
+	assert.Equal(t, "city", label.DisplayName)
+	assert.Equal(t, "test-project", TestProjectName.ProjectID)
+	assert.Equal(t, "test-record", TestRecordName.RecordID)
+	assert.Equal(t, "test.txt", TestFileName.Filename)
+}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -48,8 +48,8 @@ func TestCreateTestFileTree(t *testing.T) {
 
 func TestCaptureOutput(t *testing.T) {
 	stdout, stderr := CaptureOutput(t, func() {
-		fmt.Fprint(os.Stdout, "out")
-		fmt.Fprint(os.Stderr, "err")
+		_, _ = fmt.Fprint(os.Stdout, "out")
+		_, _ = fmt.Fprint(os.Stderr, "err")
 	})
 
 	assert.Equal(t, "out", stdout)

--- a/internal/utils/sentry_test.go
+++ b/internal/utils/sentry_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSentryRunOptionsRun(t *testing.T) {
+	done := make(chan struct{})
+
+	SentryRunOptions{RoutineName: "test-routine"}.Run(func(hub *sentry.Hub) {
+		require.NotNil(t, hub)
+		close(done)
+	})
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("sentry wrapped goroutine did not run")
+	}
+}
+
+func TestSentryHook(t *testing.T) {
+	hook := NewSentryHook()
+	assert.Equal(t, []log.Level{log.FatalLevel, log.PanicLevel}, hook.Levels())
+
+	require.NoError(t, hook.Fire(&log.Entry{Level: log.ErrorLevel, Message: "recoverable"}))
+	require.NoError(t, hook.Fire(&log.Entry{Level: log.FatalLevel, Message: "fatal"}))
+}

--- a/pkg/cmd/project/internal_helpers_test.go
+++ b/pkg/cmd/project/internal_helpers_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import (
+	"testing"
+
+	openv1alpha1service "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectTableOpts(t *testing.T) {
+	format, opts := projectTableOpts(false, "table")
+	assert.Equal(t, "table", format)
+	assert.False(t, opts.Wide)
+	assert.Equal(t, []string{"DISPLAY NAME"}, opts.OmitFields)
+
+	format, opts = projectTableOpts(true, "wide")
+	assert.Equal(t, "table", format)
+	assert.True(t, opts.Verbose)
+	assert.True(t, opts.Wide)
+	assert.Empty(t, opts.OmitFields)
+}
+
+func TestParseTemplateScopes(t *testing.T) {
+	got, err := parseTemplateScopes("custom_fields, ACTIONS,triggers, layouts")
+	require.NoError(t, err)
+	assert.Equal(t, []openv1alpha1service.CreateProjectUsingTemplateRequest_TemplateScope{
+		openv1alpha1service.CreateProjectUsingTemplateRequest_CUSTOM_FIELDS,
+		openv1alpha1service.CreateProjectUsingTemplateRequest_ACTIONS,
+		openv1alpha1service.CreateProjectUsingTemplateRequest_TRIGGERS,
+		openv1alpha1service.CreateProjectUsingTemplateRequest_LAYOUTS,
+	}, got)
+
+	got, err = parseTemplateScopes("")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	_, err = parseTemplateScopes("records")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported scope")
+}

--- a/pkg/cmd/record/internal_helpers_test.go
+++ b/pkg/cmd/record/internal_helpers_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecordTableOpts(t *testing.T) {
+	format, opts := recordTableOpts(false, "table", []string{"ARCHIVED"})
+	assert.Equal(t, "table", format)
+	assert.False(t, opts.Wide)
+	assert.Equal(t, []string{"ARCHIVED"}, opts.OmitFields)
+
+	format, opts = recordTableOpts(true, "wide", nil)
+	assert.Equal(t, "table", format)
+	assert.True(t, opts.Verbose)
+	assert.True(t, opts.Wide)
+	assert.Empty(t, opts.OmitFields)
+
+	format, opts = recordTableOpts(false, "json", nil)
+	assert.Equal(t, "json", format)
+	assert.False(t, opts.Wide)
+}

--- a/pkg/cmd/registry/registry_test.go
+++ b/pkg/cmd/registry/registry_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/internal/testutil"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistryRootCommand(t *testing.T) {
+	cfgPath := filepath.Join(testutil.TempDir(t), "config.yaml")
+	var buf bytes.Buffer
+	io := iostreams.Test(nil, &buf, &buf)
+
+	cmd := NewRootCommand(&cfgPath, io, config.Provide)
+
+	assert.Equal(t, "registry", cmd.Use)
+	assert.False(t, cmd_utils.IsAuthCheckEnabled(cmd))
+	for _, name := range []string{"login", "create-credential"} {
+		sub, _, err := cmd.Find([]string{name})
+		require.NoError(t, err)
+		assert.Equal(t, name, sub.Name())
+		assert.NotEmpty(t, sub.Short)
+	}
+}
+
+func TestCreateCredentialCommandShape(t *testing.T) {
+	cfgPath := filepath.Join(testutil.TempDir(t), "config.yaml")
+	var buf bytes.Buffer
+	io := iostreams.Test(nil, &buf, &buf)
+
+	cmd := NewCreateCredentialCommand(&cfgPath, io, config.Provide)
+
+	assert.Equal(t, "create-credential", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NoError(t, cmd.Args(cmd, nil))
+	assert.Error(t, cmd.Args(cmd, []string{"extra"}))
+	require.NotNil(t, cmd.Flag("output"))
+	assert.Equal(t, "o", cmd.Flag("output").Shorthand)
+}

--- a/pkg/cmd/root_internal_test.go
+++ b/pkg/cmd/root_internal_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRootDescriptionsIncludeReleaseContext(t *testing.T) {
+	assert.Contains(t, rootLongDescription(), "Release channel:")
+	assert.Contains(t, rootLongDescription(), "Base API endpoint:")
+	assert.Contains(t, rootVersionString(), "Download base:")
+}
+
+func TestUpdateCommandSkipsAuth(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := NewUpdateCommand(iostreams.Test(nil, &buf, &buf))
+
+	assert.Equal(t, "update", cmd.Use)
+	assert.False(t, cmd_utils.IsAuthCheckEnabled(cmd))
+	assert.NoError(t, cmd.Args(cmd, nil))
+	assert.Error(t, cmd.Args(cmd, []string{"extra"}))
+}

--- a/pkg/cmd_utils/auth_check.go
+++ b/pkg/cmd_utils/auth_check.go
@@ -30,7 +30,7 @@ func IsAuthCheckEnabled(cmd *cobra.Command) bool {
 		return false
 	}
 
-	for c := cmd; c.Parent() != nil; c = c.Parent() {
+	for c := cmd; c != nil; c = c.Parent() {
 		if c.Annotations != nil && c.Annotations["skipAuthCheck"] == "true" {
 			return false
 		}

--- a/pkg/cmd_utils/cmd_utils_test.go
+++ b/pkg/cmd_utils/cmd_utils_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd_utils
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthCheckAnnotations(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{Use: "child"}
+	root.AddCommand(child)
+
+	assert.True(t, IsAuthCheckEnabled(child))
+
+	DisableAuthCheck(root)
+	assert.False(t, IsAuthCheckEnabled(child))
+	assert.Equal(t, "true", root.Annotations["skipAuthCheck"])
+}
+
+func TestAuthCheckBuiltInCommands(t *testing.T) {
+	assert.False(t, IsAuthCheckEnabled(&cobra.Command{Use: "help"}))
+	assert.False(t, IsAuthCheckEnabled(&cobra.Command{Use: cobra.ShellCompRequestCmd}))
+	assert.False(t, IsAuthCheckEnabled(&cobra.Command{Use: cobra.ShellCompNoDescRequestCmd}))
+}
+
+func TestNewTransportUsesSafeDefaults(t *testing.T) {
+	timeout := 7 * time.Second
+
+	transport := NewTransport(timeout)
+
+	assert.Equal(t, timeout, transport.ResponseHeaderTimeout)
+	assert.Equal(t, time.Minute, transport.IdleConnTimeout)
+	assert.Equal(t, 256, transport.MaxIdleConns)
+	assert.Equal(t, 16, transport.MaxIdleConnsPerHost)
+	assert.True(t, transport.DisableCompression)
+	assert.NotNil(t, transport.TLSClientConfig)
+	assert.Equal(t, uint16(tls.VersionTLS12), transport.TLSClientConfig.MinVersion)
+}

--- a/pkg/cmd_utils/upload_utils/upload_db_test.go
+++ b/pkg/cmd_utils/upload_utils/upload_db_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upload_utils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/coscene-io/cocli/internal/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
+)
+
+func TestUploadDBLifecycle(t *testing.T) {
+	oldUploaderDir := constants.DefaultUploaderDirPath
+	constants.DefaultUploaderDirPath = t.TempDir()
+	t.Cleanup(func() {
+		constants.DefaultUploaderDirPath = oldUploaderDir
+	})
+
+	db, err := NewUploadDB("data.bin", "record-a", "sha256", 64)
+	require.NoError(t, err)
+	dbPath := db.Path()
+
+	require.NoError(t, db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte(multipartUploadsBucket)).Put(
+			[]byte("checkpoint"),
+			[]byte(`{"upload_id":"upload-1","uploaded_size":42}`),
+		)
+	}))
+
+	var checkpoint MultipartCheckpointInfo
+	require.NoError(t, db.Get("checkpoint", &checkpoint))
+	assert.Equal(t, "upload-1", checkpoint.UploadId)
+	assert.Equal(t, int64(42), checkpoint.UploadedSize)
+
+	require.NoError(t, db.Reset())
+	require.NoError(t, db.View(func(tx *bolt.Tx) error {
+		got := tx.Bucket([]byte(multipartUploadsBucket)).Get([]byte("checkpoint"))
+		assert.Nil(t, got)
+		return nil
+	}))
+
+	require.NoError(t, db.Delete())
+	_, err = os.Stat(dbPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/pkg/cmd_utils/upload_utils/upload_manager_test.go
+++ b/pkg/cmd_utils/upload_utils/upload_manager_test.go
@@ -15,10 +15,20 @@
 package upload_utils
 
 import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/coscene-io/cocli/internal/constants"
+	"github.com/coscene-io/cocli/internal/fs"
+	"github.com/coscene-io/cocli/internal/name"
+	"github.com/minio/minio-go/v7"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -134,4 +144,314 @@ func TestUploadManager_View(t *testing.T) {
 		u := model.(*UploadManager)
 		assert.Equal(t, 120, u.windowWidth)
 	})
+
+	t.Run("Update marks manual quit on escape keys", func(t *testing.T) {
+		um := &UploadManager{}
+		model, cmd := um.Update(tea.KeyMsg{Type: tea.KeyEscape})
+		u := model.(*UploadManager)
+		assert.True(t, u.manualQuit)
+		assert.NotNil(t, cmd)
+	})
+}
+
+func TestUploadParents(t *testing.T) {
+	recordName, err := name.NewRecord("projects/project-a/records/record-a")
+	require.NoError(t, err)
+	recordParent := NewRecordParent(recordName)
+	assert.Equal(t, "projects/project-a/records/record-a", recordParent.ParentString())
+	assert.Equal(t, "projects/project-a/records/record-a/files/data/file.txt", recordParent.BuildResourceName("data/file.txt"))
+
+	projectName, err := name.NewProject("projects/project-a")
+	require.NoError(t, err)
+	projectParent := NewProjectParent(projectName)
+	assert.Equal(t, "projects/project-a", projectParent.ParentString())
+	assert.Equal(t, "projects/project-a/files/data/file.txt", projectParent.BuildResourceName("data/file.txt"))
+
+	ctx := newParentContextFrom(projectParent)
+	assert.Equal(t, "projects/project-a", ctx.parentString)
+	assert.Equal(t, "projects/project-a/files/other.txt", ctx.buildResourceName("other.txt"))
+}
+
+func TestUploadManager_ParseUrl(t *testing.T) {
+	um := &UploadManager{}
+
+	bucket, key, tags, err := um.parseUrl("https://oss.example.com/upload-bucket/path/to/file.txt?X-Amz-Tagging=X-COS-RECORD-ID%3Drecord-a%26X-COS-PROJECT-ID%3Dproject-a")
+
+	require.NoError(t, err)
+	assert.Equal(t, "upload-bucket", bucket)
+	assert.Equal(t, "path/to/file.txt", key)
+	assert.Equal(t, map[string]string{
+		"X-COS-RECORD-ID":  "record-a",
+		"X-COS-PROJECT-ID": "project-a",
+	}, tags)
+}
+
+func TestUploadManager_CanUpload(t *testing.T) {
+	um := &UploadManager{opts: &UploadManagerOpts{partSizeUint64: 512 * 1024 * 1024}}
+
+	assert.True(t, um.canUpload(UploadInfo{Path: "a", PartId: 20}, nil))
+	assert.True(t, um.canUpload(
+		UploadInfo{Path: "a", PartId: 3},
+		[]UploadInfo{{Path: "a", PartId: 1}, {Path: "b", PartId: 99}},
+	))
+	assert.False(t, um.canUpload(
+		UploadInfo{Path: "a", PartId: 4},
+		[]UploadInfo{{Path: "a", PartId: 1}},
+	))
+}
+
+func TestUploadManager_StateHelpers(t *testing.T) {
+	um := &UploadManager{
+		fileInfos: make(map[string]*FileInfo),
+		errs:      make(map[string]error),
+		noTTY:     true,
+	}
+
+	um.addFile("a.txt")
+	require.Contains(t, um.fileInfos, "a.txt")
+	assert.Equal(t, []string{"a.txt"}, um.fileList)
+
+	um.uploadWg.Add(1)
+	um.addErr("a.txt", assert.AnError)
+	assert.Equal(t, UploadFailed, um.fileInfos["a.txt"].Status)
+	assert.ErrorIs(t, um.errs["a.txt"], assert.AnError)
+}
+
+func TestUploadManager_UpdateUploadSpeeds(t *testing.T) {
+	um := &UploadManager{
+		fileList: []string{"a", "b"},
+		fileInfos: map[string]*FileInfo{
+			"a": {Path: "a", Status: UploadInProgress, Uploaded: 400},
+			"b": {Path: "b", Status: UploadCompleted, Uploaded: 400},
+		},
+		lastSpeedSample: map[string]struct {
+			uploaded int64
+			t        time.Time
+		}{
+			"a": {uploaded: 100, t: time.Now().Add(-time.Second)},
+		},
+	}
+
+	um.updateUploadSpeeds()
+
+	assert.Greater(t, um.fileInfos["a"].SpeedBps, float64(0))
+	assert.Equal(t, float64(0), um.fileInfos["b"].SpeedBps)
+}
+
+func TestUploadProgressReaders(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.txt")
+	require.NoError(t, os.WriteFile(path, []byte("abcdef"), 0644))
+
+	t.Run("file reader reports bytes read", func(t *testing.T) {
+		file, err := os.Open(path)
+		require.NoError(t, err)
+		defer func() { _ = file.Close() }()
+
+		ch := make(chan IncUploadedMsg, 1)
+		reader := &uploadProgressReader{
+			File:       file,
+			fileInfo:   &FileInfo{Path: path},
+			progressCh: ch,
+		}
+
+		buf := make([]byte, 3)
+		n, err := reader.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, 3, n)
+		assert.Equal(t, IncUploadedMsg{Path: path, UploadedInc: 3}, <-ch)
+	})
+
+	t.Run("section reader reports bytes read", func(t *testing.T) {
+		file, err := os.Open(path)
+		require.NoError(t, err)
+		defer func() { _ = file.Close() }()
+
+		ch := make(chan IncUploadedMsg, 1)
+		reader := &uploadProgressSectionReader{
+			SectionReader: io.NewSectionReader(file, 2, 2),
+			fileInfo:      &FileInfo{Path: path},
+			progressCh:    ch,
+		}
+
+		buf := make([]byte, 2)
+		n, err := reader.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, 2, n)
+		assert.Equal(t, "cd", string(buf))
+		assert.Equal(t, IncUploadedMsg{Path: path, UploadedInc: 2}, <-ch)
+	})
+}
+
+func TestUploadManager_FindAllUploadUrls(t *testing.T) {
+	dir := t.TempDir()
+	skipPath := filepath.Join(dir, "skip.txt")
+	uploadPath := filepath.Join(dir, "upload.txt")
+	require.NoError(t, os.WriteFile(skipPath, []byte("already there"), 0644))
+	require.NoError(t, os.WriteFile(uploadPath, []byte("new data"), 0644))
+
+	skipSha, skipSize, err := fs.CalSha256AndSize(skipPath)
+	require.NoError(t, err)
+
+	projectName, err := name.NewProject("projects/project-a")
+	require.NoError(t, err)
+	api := &fakeUploadFileAPI{
+		existing: map[string]*openv1alpha1resource.File{
+			"projects/project-a/files/remote/skip.txt": {
+				Name:   "projects/project-a/files/remote/skip.txt",
+				Sha256: skipSha,
+				Size:   skipSize,
+			},
+		},
+		uploadURLs: map[string]string{
+			"projects/project-a/files/remote/upload.txt": "https://oss.example.com/bucket/remote/upload.txt?X-Amz-Tagging=X-COS-PROJECT-ID%3Dproject-a",
+		},
+	}
+	um := &UploadManager{
+		apiOpts:   &ApiOpts{FileInterface: api},
+		fileInfos: make(map[string]*FileInfo),
+		errs:      make(map[string]error),
+		noTTY:     true,
+	}
+	um.uploadWg.Add(1)
+
+	got := um.findAllUploadUrls(
+		context.Background(),
+		[]string{skipPath, uploadPath},
+		newParentContextFrom(NewProjectParent(projectName)),
+		dir,
+		"remote",
+	)
+
+	assert.Equal(t, map[string]string{uploadPath: "https://oss.example.com/bucket/remote/upload.txt?X-Amz-Tagging=X-COS-PROJECT-ID%3Dproject-a"}, got)
+	assert.Equal(t, PreviouslyUploaded, um.fileInfos[skipPath].Status)
+	assert.Equal(t, WaitingForUpload, um.fileInfos[uploadPath].Status)
+	assert.Equal(t, "remote/upload.txt", um.fileInfos[uploadPath].RemotePath)
+	require.Len(t, api.generatedFiles, 1)
+	assert.Equal(t, "projects/project-a/files/remote/upload.txt", api.generatedFiles[0].Name)
+}
+
+func TestUploadManager_ProduceUploadInfosForSingleFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "small.txt")
+	require.NoError(t, os.WriteFile(path, []byte("small"), 0644))
+
+	um := &UploadManager{
+		opts: &UploadManagerOpts{partSizeUint64: 1024},
+		fileInfos: map[string]*FileInfo{
+			path: {Path: path, Size: 5},
+		},
+		fileList: []string{path},
+		errs:     make(map[string]error),
+	}
+	ch := make(chan UploadInfo, 1)
+
+	um.produceUploadInfos(context.Background(), map[string]string{
+		path: "https://oss.example.com/bucket/key.txt?X-Amz-Tagging=X-COS-RECORD-ID%3Drecord-a",
+	}, ch)
+
+	info, ok := <-ch
+	require.True(t, ok)
+	defer func() { _ = info.FileReader.Close() }()
+	assert.Equal(t, path, info.Path)
+	assert.Equal(t, "bucket", info.Bucket)
+	assert.Equal(t, "key.txt", info.Key)
+	assert.Equal(t, map[string]string{"X-COS-RECORD-ID": "record-a"}, info.Tags)
+
+	_, ok = <-ch
+	assert.False(t, ok)
+}
+
+func TestUploadManager_HandleUploadResult(t *testing.T) {
+	t.Run("single upload marks file complete", func(t *testing.T) {
+		um := &UploadManager{
+			fileInfos: map[string]*FileInfo{"file.txt": {Path: "file.txt"}},
+			noTTY:     true,
+		}
+		um.uploadWg.Add(1)
+
+		require.NoError(t, um.handleUploadResult(UploadInfo{Path: "file.txt"}))
+		assert.Equal(t, UploadCompleted, um.fileInfos["file.txt"].Status)
+	})
+
+	t.Run("error result is returned", func(t *testing.T) {
+		um := &UploadManager{}
+		err := um.handleUploadResult(UploadInfo{Err: assert.AnError})
+		assert.ErrorIs(t, err, assert.AnError)
+	})
+
+	t.Run("multipart upload writes checkpoint before completion", func(t *testing.T) {
+		oldUploaderDir := constants.DefaultUploaderDirPath
+		constants.DefaultUploaderDirPath = t.TempDir()
+		t.Cleanup(func() {
+			constants.DefaultUploaderDirPath = oldUploaderDir
+		})
+
+		filePath := filepath.Join(t.TempDir(), "large.bin")
+		require.NoError(t, os.WriteFile(filePath, []byte("large"), 0644))
+		file, err := os.Open(filePath)
+		require.NoError(t, err)
+		defer func() { _ = file.Close() }()
+
+		db, err := NewUploadDB(filePath, "record-a", "sha", 2)
+		require.NoError(t, err)
+		defer func() { _ = db.Delete() }()
+
+		um := &UploadManager{
+			fileInfos: map[string]*FileInfo{filePath: {Path: filePath}},
+			noTTY:     true,
+		}
+
+		result := UploadInfo{
+			Path:            filePath,
+			UploadId:        "upload-a",
+			TotalPartsCount: 2,
+			ReadSize:        2,
+			Result:          minio.ObjectPart{PartNumber: 1, ETag: "etag-1"},
+			FileReader:      file,
+			DB:              db,
+		}
+		require.NoError(t, um.handleUploadResult(result))
+
+		var checkpoint MultipartCheckpointInfo
+		require.NoError(t, db.Get(mutipartUploadInfoKey, &checkpoint))
+		assert.Equal(t, "upload-a", checkpoint.UploadId)
+		assert.Equal(t, int64(2), checkpoint.UploadedSize)
+		require.Len(t, checkpoint.Parts, 1)
+		assert.Equal(t, 1, checkpoint.Parts[0].PartNumber)
+	})
+}
+
+type fakeUploadFileAPI struct {
+	existing       map[string]*openv1alpha1resource.File
+	uploadURLs     map[string]string
+	generatedFiles []*openv1alpha1resource.File
+}
+
+func (f *fakeUploadFileAPI) GetFile(ctx context.Context, fileResourceName string) (*openv1alpha1resource.File, error) {
+	if file, ok := f.existing[fileResourceName]; ok {
+		return file, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (f *fakeUploadFileAPI) GenerateFileUploadUrls(ctx context.Context, parent string, files []*openv1alpha1resource.File) (map[string]string, error) {
+	f.generatedFiles = append(f.generatedFiles, files...)
+	ret := make(map[string]string, len(files))
+	for _, file := range files {
+		ret[file.Name] = f.uploadURLs[file.Name]
+	}
+	return ret, nil
+}
+
+func (f *fakeUploadFileAPI) GenerateFileDownloadUrl(ctx context.Context, fileResourceName string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (f *fakeUploadFileAPI) DeleteFile(ctx context.Context, fileResourceName string) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeUploadFileAPI) BatchDeleteFiles(ctx context.Context, parent string, names []string) error {
+	return errors.New("not implemented")
 }

--- a/pkg/cmd_utils/url_utils.go
+++ b/pkg/cmd_utils/url_utils.go
@@ -82,22 +82,24 @@ func DownloadFileThroughUrl(file string, downloadUrl string, maxRetries int) err
 		return errors.Wrapf(err, "unable to create directories for file %v", file)
 	}
 
-	fileWriter, err := os.Create(file)
-	if err != nil {
-		return errors.Wrapf(err, "unable to open file %v for writing", file)
-	}
-	defer func() { _ = fileWriter.Close() }()
-
 	var attempt int
 
 	operation := func() error {
+		fileWriter, err := os.Create(file)
+		if err != nil {
+			return errors.Wrapf(err, "unable to open file %v for writing", file)
+		}
+
 		opErr := downloadWithFileWriter(fileWriter, downloadUrl, attempt)
+		closeErr := fileWriter.Close()
 		if opErr != nil {
 			retryPrefix := ""
 			if attempt > 0 {
 				retryPrefix = fmt.Sprintf("(Retry #%d) ", attempt)
 			}
 			log.Errorf("%sUnable to download file: %v", retryPrefix, opErr)
+		} else if closeErr != nil {
+			opErr = errors.Wrapf(closeErr, "unable to close file %v", file)
 		}
 		attempt++
 		return opErr
@@ -127,6 +129,10 @@ func downloadWithFileWriter(fileWriter *os.File, downloadUrl string, retry int) 
 		return errors.Wrapf(err, "unable to get file from url %v", downloadUrl)
 	}
 	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return errors.Errorf("unexpected HTTP status %s", resp.Status)
+	}
 
 	progress := &Progress{
 		PrintPrefix: "File download in progress",

--- a/pkg/cmd_utils/url_utils_test.go
+++ b/pkg/cmd_utils/url_utils_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd_utils
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/coscene-io/cocli/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProgress_WriteAccumulatesBytes(t *testing.T) {
+	progress := &Progress{TotalSize: 10, PrintPrefix: "download"}
+
+	n, err := progress.Write([]byte("abc"))
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+	assert.Equal(t, int64(3), progress.BytesRead)
+}
+
+func TestDownloadFileThroughUrl(t *testing.T) {
+	t.Run("downloads into nested destination", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("hello"))
+		}))
+		defer server.Close()
+
+		dst := filepath.Join(t.TempDir(), "nested", "file.txt")
+		require.NoError(t, DownloadFileThroughUrl(dst, server.URL, 0))
+		assertFileContent(t, dst, "hello")
+	})
+
+	t.Run("non-successful HTTP status fails", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "nope", http.StatusForbidden)
+		}))
+		defer server.Close()
+
+		dst := filepath.Join(t.TempDir(), "file.txt")
+		err := DownloadFileThroughUrl(dst, server.URL, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "403 Forbidden")
+	})
+
+	t.Run("retry starts from a clean file", func(t *testing.T) {
+		var attempts int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if atomic.AddInt32(&attempts, 1) == 1 {
+				w.Header().Set("Content-Length", "8")
+				_, _ = w.Write([]byte("bad"))
+				return
+			}
+			_, _ = w.Write([]byte("good"))
+		}))
+		defer server.Close()
+
+		dst := filepath.Join(t.TempDir(), "file.txt")
+		require.NoError(t, DownloadFileThroughUrl(dst, server.URL, 1))
+		assertFileContent(t, dst, "good")
+		assert.Equal(t, int32(2), atomic.LoadInt32(&attempts))
+	})
+}
+
+func TestSaveMomentsJson(t *testing.T) {
+	dir := t.TempDir()
+	moments := []*api.Moment{
+		{
+			Name:        "moments/one",
+			Description: "interesting point",
+			Attribute:   map[string]string{"kind": "brake"},
+		},
+	}
+
+	require.NoError(t, SaveMomentsJson(moments, dir))
+
+	data, err := os.ReadFile(filepath.Join(dir, "moments.json"))
+	require.NoError(t, err)
+
+	var payload struct {
+		Moments []*api.Moment `json:"moments"`
+	}
+	require.NoError(t, json.Unmarshal(data, &payload))
+	require.Len(t, payload.Moments, 1)
+	assert.Equal(t, "moments/one", payload.Moments[0].Name)
+	assert.Equal(t, "brake", payload.Moments[0].Attribute["kind"])
+}
+
+func assertFileContent(t *testing.T, path string, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, want, string(got))
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cocli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetVersion(t *testing.T) {
+	oldVersion := version
+	oldGitCommit := gitCommit
+	oldGitTag := gitTag
+	oldGitTreeState := gitTreeState
+	t.Cleanup(func() {
+		version = oldVersion
+		gitCommit = oldGitCommit
+		gitTag = oldGitTag
+		gitTreeState = oldGitTreeState
+	})
+
+	version = "v1.2.3"
+	gitCommit = "abcdef123456"
+	gitTag = ""
+	gitTreeState = "dirty"
+	assert.Equal(t, "v1.2.3+abcdef1.dirty", GetVersion())
+
+	gitTreeState = "clean"
+	assert.Equal(t, "v1.2.3+abcdef1", GetVersion())
+
+	gitTag = "v1.2.4"
+	assert.Equal(t, "v1.2.4", GetVersion())
+
+	gitCommit = "abc"
+	gitTag = ""
+	assert.Equal(t, "v1.2.3+unknown", GetVersion())
+}


### PR DESCRIPTION
## What changed
- Added focused unit tests across API clients, config/profile logic, printers, prompt models, command helpers, upload helpers, and version formatting.
- Covered download retry behavior, upload checkpoint/progress helpers, table/JSON/YAML printers, custom field formatting, and small API wrapper clients.
- Hardened a few tiny edge cases found while testing: nil printer options, inherited auth-skip annotations, HTTP status handling for downloads, and clean file recreation between download retries.

## Validation
- `go test ./...`
- `go test ./... -coverprofile=coverage.out`
- `go test -race -coverprofile=coverage.txt -covermode=atomic ./...`
- `make lint`
- `go tool cover -func=coverage.txt | tail -n 1` -> total statement coverage `52.5%`
- GitHub checks: build, macOS test, Ubuntu test, and codecov all passed.

## Coverage note
- Baseline statement coverage was `30.9%`; this PR raises it to `52.5%` with readable unit tests.
- The main remaining uncovered blocks are CLI `Run` closures and full upload scheduling paths that depend on real profile/API/minio flows; I stopped short of heavy mock scaffolding that would make tests harder to review than the code paths they cover.