### PR TITLE
[codex] 修复文件资源名中 files 目录导致解析错位的问题

### DIFF
--- a/internal/name/file.go
+++ b/internal/name/file.go
@@ -28,7 +28,7 @@ type File struct {
 }
 
 var (
-	fileRe = regroup.MustCompile(`^projects/(?P<project>.*)/records/(?P<record>.*)/files/(?P<file>.*)$`)
+	fileRe = regroup.MustCompile(`^projects/(?P<project>[^/]+)/records/(?P<record>[^/]+)/files/(?P<file>.*)$`)
 )
 
 func NewFile(file string) (*File, error) {

--- a/internal/name/name_test.go
+++ b/internal/name/name_test.go
@@ -89,6 +89,7 @@ func TestNewFile(t *testing.T) {
 	}{
 		{"valid", "projects/p1/records/r1/files/data.bin", "p1", "r1", "data.bin", false},
 		{"nested path", "projects/p1/records/r1/files/dir/sub/file.txt", "p1", "r1", "dir/sub/file.txt", false},
+		{"nested reserved segments", "projects/p1/records/r1/files/dir/files/records/data.bin", "p1", "r1", "dir/files/records/data.bin", false},
 		{"missing files segment", "projects/p1/records/r1/data.bin", "", "", "", true},
 		{"empty", "", "", "", "", true},
 	}
@@ -247,6 +248,7 @@ func TestNewProjectFile(t *testing.T) {
 	}{
 		{"valid", "projects/p1/files/readme.md", "p1", "readme.md", false},
 		{"nested path", "projects/p1/files/dir/sub/file.txt", "p1", "dir/sub/file.txt", false},
+		{"nested files segment", "projects/p1/files/dir/files/readme.md", "p1", "dir/files/readme.md", false},
 		{"missing files segment", "projects/p1/readme.md", "", "", true},
 		{"empty", "", "", "", true},
 	}

--- a/internal/name/project_file.go
+++ b/internal/name/project_file.go
@@ -29,7 +29,7 @@ type ProjectFile struct {
 }
 
 var (
-	projectFileRe = regroup.MustCompile(`^projects/(?P<project>.*)/files/(?P<file>.*)$`)
+	projectFileRe = regroup.MustCompile(`^projects/(?P<project>[^/]+)/files/(?P<file>.*)$`)
 )
 
 func NewProjectFile(file string) (*ProjectFile, error) {


### PR DESCRIPTION
## 问题
`internal/name` 解析文件资源名时，project / record 分组使用贪婪匹配。文件名里如果也包含 `/files/` 或 `/records/` 目录名，解析会从后面的分隔符切开，导致 project、record 或 filename 错位。

## 复现步骤
1. 解析 `projects/p1/records/r1/files/dir/files/records/data.bin`。
2. 旧逻辑可能把 `record` 解析成 `r1/files/dir`，把 filename 解析成 `records/data.bin`。
3. 这会影响下载、删除、展示等依赖资源名解析的路径。

## 修复
- `File` / `ProjectFile` 的 project、record 分组改成单个 path segment。
- filename 仍然保留后续完整路径，允许正常的多级目录。

## 测试与 regression
- 新增测试覆盖 filename 中包含 `files` / `records` 目录名的资源名。
- 普通文件名和多级目录解析保持不变。
- 已验证：`go test ./internal/name`、`go test ./...`、`make lint`。