### PR TITLE
[codex] 修复文件目录过滤条件未转义的问题

### DIFF
--- a/pkg/cmd/project/file.go
+++ b/pkg/cmd/project/file.go
@@ -15,7 +15,6 @@
 package project
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -83,18 +82,7 @@ func NewFileListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fu
 			}
 
 			var files []*openv1alpha1resource.File
-			var filterParts []string
-
-			// Build filter
-			if recursive {
-				filterParts = append(filterParts, "recursive=\"true\"")
-			}
-			if dir != "" {
-				// Normalize: ensure no trailing slash for filter consistency
-				normalizedDir := strings.TrimSuffix(dir, "/")
-				filterParts = append(filterParts, fmt.Sprintf("dir=\"%s\"", normalizedDir))
-			}
-			additionalFilter := strings.Join(filterParts, " AND ")
+			additionalFilter := cmd_utils.FileDirFilter(dir, recursive)
 
 			if all {
 				if additionalFilter != "" {
@@ -217,8 +205,7 @@ func NewFileDownloadCommand(cfgPath *string, io *iostreams.IOStreams, getProvide
 			var files []*openv1alpha1resource.File
 			if dir != "" {
 				// Download specific directory recursively
-				normalizedDir := strings.TrimSuffix(dir, "/")
-				files, err = pm.ProjectCli().ListAllFilesWithFilter(cmd.Context(), projectName, fmt.Sprintf("dir=\"%s\" AND recursive=\"true\"", normalizedDir))
+				files, err = pm.ProjectCli().ListAllFilesWithFilter(cmd.Context(), projectName, cmd_utils.FileDirFilter(dir, true))
 				if err != nil {
 					log.Fatalf("unable to list project files: %v", err)
 				}

--- a/pkg/cmd/record/file.go
+++ b/pkg/cmd/record/file.go
@@ -15,7 +15,6 @@
 package record
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,16 +96,7 @@ func NewFileListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fu
 
 			var files []*openv1alpha1resource.File
 
-			// Build filter
-			var filterParts []string
-			if recursive {
-				filterParts = append(filterParts, "recursive=\"true\"")
-			}
-			if dir != "" {
-				normalizedDir := strings.TrimSuffix(dir, "/")
-				filterParts = append(filterParts, fmt.Sprintf("dir=\"%s\"", normalizedDir))
-			}
-			filterStr := strings.Join(filterParts, " AND ")
+			filterStr := cmd_utils.FileDirFilter(dir, recursive)
 
 			if all {
 				if filterStr != "" {
@@ -239,8 +229,7 @@ func NewFileDownloadCommand(cfgPath *string, io *iostreams.IOStreams, getProvide
 			var files []*openv1alpha1resource.File
 			if dir != "" {
 				// Download specific directory recursively
-				normalizedDir := strings.TrimSuffix(dir, "/")
-				files, err = pm.RecordCli().ListAllFilesWithFilter(cmd.Context(), recordName, fmt.Sprintf("dir=\"%s\" AND recursive=\"true\"", normalizedDir))
+				files, err = pm.RecordCli().ListAllFilesWithFilter(cmd.Context(), recordName, cmd_utils.FileDirFilter(dir, true))
 				if err != nil {
 					log.Fatalf("unable to list record files: %v", err)
 				}

--- a/pkg/cmd_utils/file_filter.go
+++ b/pkg/cmd_utils/file_filter.go
@@ -1,0 +1,33 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd_utils
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func FileDirFilter(dir string, recursive bool) string {
+	var filterParts []string
+	if recursive {
+		filterParts = append(filterParts, `recursive="true"`)
+	}
+	if dir != "" {
+		normalizedDir := strings.TrimSuffix(dir, "/")
+		filterParts = append(filterParts, fmt.Sprintf("dir=%s", strconv.Quote(normalizedDir)))
+	}
+	return strings.Join(filterParts, " AND ")
+}

--- a/pkg/cmd_utils/file_filter_test.go
+++ b/pkg/cmd_utils/file_filter_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd_utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileDirFilter(t *testing.T) {
+	tests := []struct {
+		name      string
+		dir       string
+		recursive bool
+		want      string
+	}{
+		{name: "empty", want: ""},
+		{name: "recursive only", recursive: true, want: `recursive="true"`},
+		{name: "trim trailing slash", dir: "logs/", want: `dir="logs"`},
+		{name: "escape quote", dir: `logs" OR recursive="true`, want: `dir="logs\" OR recursive=\"true"`},
+		{name: "escape backslash", dir: `logs\raw`, want: `dir="logs\\raw"`},
+		{name: "recursive and dir", dir: "logs", recursive: true, want: `recursive="true" AND dir="logs"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, FileDirFilter(tt.dir, tt.recursive))
+		})
+	}
+}


### PR DESCRIPTION
## 问题
record/project 的 `file list --dir` 和 `file download --dir` 直接把用户输入拼进 `dir="..."` filter。目录名里如果包含引号或反斜杠，生成的 filter 会被截断、解析失败，甚至改变后续条件。

## 复现步骤
1. 准备一个已登录的 `cocli` profile，并把 `<record-resource-name/id>`、`<project-resource-name/slug>`、`<dst-dir>` 换成可访问资源。
2. 执行 record 文件列表或下载：
   ```sh
   cocli record file list <record-resource-name/id> --dir 'logs" OR recursive="true' -R
   cocli record file download <record-resource-name/id> <dst-dir> --dir 'logs" OR recursive="true'
   ```
3. 同一类问题也存在于 project 文件命令：
   ```sh
   cocli project file list <project-resource-name/slug> --dir 'logs" OR recursive="true' -R
   cocli project file download <project-resource-name/slug> <dst-dir> --dir 'logs" OR recursive="true'
   ```
4. Actual：修复前会生成类似 `dir="logs" OR recursive="true"` 的 filter，目录值提前结束，后面的内容会变成 filter 语法的一部分。
5. Expected：`--dir` 的值应该整体作为目录字符串传给服务端；即使目录名包含 `"` 或 `\`，也不应该改变 filter 结构。

## 修复
- 新增 `cmd_utils.FileDirFilter` 统一构造目录 filter。
- 用 `strconv.Quote` 转义目录值，并继续保留尾部 `/` 归一化。
- record/project 的 `file list --dir`、`file download --dir` 共用同一逻辑。

## 测试与 regression
- 新增测试覆盖普通目录、尾部 `/`、引号、反斜杠、recursive 组合。
- 普通 `--dir logs`、`--dir logs/` 和 `-R` 的 filter 语义保持不变。
- 已验证：`go test ./pkg/cmd_utils ./pkg/cmd/record ./pkg/cmd/project`、`go test ./...`、`make lint`。
