### PR TITLE
[codex] 修复项目资源名解析接受多余路径的问题

### DIFF
--- a/internal/name/name_test.go
+++ b/internal/name/name_test.go
@@ -30,7 +30,7 @@ func TestNewProject(t *testing.T) {
 	}{
 		{"valid", "projects/abc-123", "abc-123", false},
 		{"valid uuid", "projects/d9b9d56b-0d43-4719-b7cc-0d7e6616bb8a", "d9b9d56b-0d43-4719-b7cc-0d7e6616bb8a", false},
-		{"empty id", "projects/", "", false},
+		{"empty id", "projects/", "", true},
 		{"invalid prefix", "repos/abc", "", true},
 		{"empty string", "", "", true},
 		{"no slash", "projects", "", true},

--- a/internal/name/project.go
+++ b/internal/name/project.go
@@ -26,7 +26,7 @@ type Project struct {
 }
 
 var (
-	projectRe = regroup.MustCompile(`^projects/(?P<project>[^/]*)$`)
+	projectRe = regroup.MustCompile(`^projects/(?P<project>[^/]+)$`)
 )
 
 func NewProject(project string) (*Project, error) {

--- a/internal/name/project_parser_test.go
+++ b/internal/name/project_parser_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 coScene
+// Copyright 2026 coScene
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,28 +15,13 @@
 package name
 
 import (
-	"fmt"
+	"testing"
 
-	"github.com/oriser/regroup"
-	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
-type Project struct {
-	ProjectID string
-}
+func TestNewProjectRejectsNestedResourcePath(t *testing.T) {
+	_, err := NewProject("projects/p1/records/r1")
 
-var (
-	projectRe = regroup.MustCompile(`^projects/(?P<project>[^/]*)$`)
-)
-
-func NewProject(project string) (*Project, error) {
-	if match, err := projectRe.Groups(project); err != nil {
-		return nil, errors.Wrap(err, "parse project name")
-	} else {
-		return &Project{ProjectID: match["project"]}, nil
-	}
-}
-
-func (p Project) String() string {
-	return fmt.Sprintf("projects/%s", p.ProjectID)
+	require.Error(t, err)
 }


### PR DESCRIPTION
## 问题
项目资源名 parser 会把 `projects/p1/records/r1` 这种更深的资源路径当成合法 project name，并把 project ID 解析成 `p1/records/r1`；`projects/` 这种空 project ID 也会被接受。

## 复现步骤
1. 准备一个已登录的 `cocli` profile。
2. 执行：
   ```sh
   cocli project create -p "repro-project-$(date +%s)" -n "repro project" -b private --template projects/p1/records/r1 --scope ACTIONS -y
   ```
3. Actual：修复前，CLI 本地会接受这个 `--template`，把它当成 project resource name 继续请求模板项目 `projects/p1/records/r1`。类似地，`--template projects/` 也会被当成空 project ID 继续处理。
4. Expected：`--template` 如果传完整 project resource name，只应该接受 `projects/<project-id>`；`projects/p1/records/r1` 和 `projects/` 都应该在本地被判定为无效模板项目名。

## 修复
- project ID 只匹配一个非空 path segment。
- 因此 `projects/p1` 仍然合法；`projects/p1/records/r1` 和 `projects/` 不再匹配 project resource name，命令会停在 `invalid template project name` 这一步。

## 测试与 regression
- 新增测试覆盖嵌套资源路径和空 project ID 应解析失败。
- 普通 `projects/p1` 解析保持不变。
- 已验证：`go test ./internal/name`、`go test ./...`、`make lint`。
