### PR TITLE
[codex] 修复 Action 资源名解析接受多余路径的问题

### DIFF
--- a/internal/name/action.go
+++ b/internal/name/action.go
@@ -27,7 +27,7 @@ type Action struct {
 }
 
 var (
-	actionNameRe = regroup.MustCompile(`(^projects/(?P<project>.*)/actions/(?P<id>.*)$)|(^wftmpls/(?P<wftmplID>.*)$)`)
+	actionNameRe = regroup.MustCompile(`(^projects/(?P<project>[^/]+)/actions/(?P<id>[^/]+)$)|(^wftmpls/(?P<wftmplID>[^/]+)$)`)
 )
 
 func NewAction(action string) (*Action, error) {

--- a/internal/name/action_parser_test.go
+++ b/internal/name/action_parser_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package name
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewActionRejectsNestedResourcePath(t *testing.T) {
+	_, err := NewAction("projects/p1/actions/a1/runs/run1")
+
+	require.Error(t, err)
+}
+
+func TestNewActionRejectsNestedWftmplPath(t *testing.T) {
+	_, err := NewAction("wftmpls/tmpl1/actions/a1")
+
+	require.Error(t, err)
+}
+
+func TestNewActionRunRejectsNestedResourcePath(t *testing.T) {
+	_, err := NewActionRun("projects/p1/actionRuns/run1/logs/log1")
+
+	require.Error(t, err)
+}

--- a/internal/name/action_run.go
+++ b/internal/name/action_run.go
@@ -27,7 +27,7 @@ type ActionRun struct {
 }
 
 var (
-	actionRunNameRe = regroup.MustCompile(`^projects/(?P<project>.*)/actionRuns/(?P<acr>.*)$`)
+	actionRunNameRe = regroup.MustCompile(`^projects/(?P<project>[^/]+)/actionRuns/(?P<acr>[^/]+)$`)
 )
 
 func NewActionRun(acr string) (*ActionRun, error) {


### PR DESCRIPTION
## 问题
Action / ActionRun resource name parser 会把更深的资源路径当成合法 name，并把后续 path segment 吞进 action ID、wftmpl ID 或 action run ID。

## 复现步骤
1. 准备一个已登录的 `cocli` profile，并把 `<project-slug>` 换成任意可访问项目。
2. 执行：
   ```sh
   cocli action run projects/p1/actions/a1/runs/run1 projects/p1/records/r1 -p <project-slug> --skip-params -f
   ```
3. Actual：修复前，CLI 会把 `projects/p1/actions/a1/runs/run1` 当成 action resource name，并把 action ID 解析成 `a1/runs/run1` 后继续请求。
4. Expected：action resource name 只应该是 `projects/<project-id>/actions/<action-id>` 或 `wftmpls/<template-id>`；多出来的 `/runs/run1` 应该被判定为无效 action name。
5. 同一类问题也会在 action run 列表展示路径触发：
   ```sh
   cocli action list-run -p <project-slug>
   ```
   如果服务端返回 `projects/p1/actionRuns/run1/logs/log1`，修复前会把 `run1/logs/log1` 当 action run ID；预期是这类多余路径不应被当成合法 ActionRun name。

## 修复
- project ID、action ID、wftmpl ID、action run ID 都只匹配单个 path segment。
- 因此普通 Action / ActionRun name 保持不变；带额外路径的 name 不再通过解析。

## 测试与 regression
- 新增测试覆盖 Action、wftmpl、ActionRun 后接多余路径时应解析失败。
- 普通 `projects/p1/actions/a1`、`wftmpls/tmpl1`、`projects/p1/actionRuns/run1` 解析保持不变。
- 已验证：`go test ./internal/name`、`go test ./...`、`make lint`。
