### PR TITLE
[codex] 修复用户资源名解析接受多余路径的问题

### DIFF
--- a/internal/name/name_test.go
+++ b/internal/name/name_test.go
@@ -221,6 +221,9 @@ func TestNewUser(t *testing.T) {
 		wantErr bool
 	}{
 		{"valid", "users/user-123", "user-123", false},
+		{"current", "users/current", "current", false},
+		{"extra path", "users/user-123/projects/p1", "", true},
+		{"empty user id", "users/", "", true},
 		{"invalid prefix", "people/user-123", "", true},
 		{"empty", "", "", true},
 	}

--- a/internal/name/user.go
+++ b/internal/name/user.go
@@ -26,12 +26,12 @@ type User struct {
 }
 
 var (
-	userRe = regroup.MustCompile(`^users\/(?P<user>.*)$`)
+	userRe = regroup.MustCompile(`^users/(?P<user>[^/]+)$`)
 )
 
 func NewUser(user string) (*User, error) {
 	if match, err := userRe.Groups(user); err != nil {
-		return nil, errors.Wrap(err, "parse workflow template name")
+		return nil, errors.Wrap(err, "parse user name")
 	} else {
 		return &User{UserID: match["user"]}, nil
 	}


### PR DESCRIPTION
## 问题
user resource name parser 会把 `users/u1/projects/p1` 这种更深的路径当成合法 user name，并把 user ID 解析成 `u1/projects/p1`。

## 复现步骤
1. 准备一个已登录的 `cocli` profile。
2. 执行：
   ```sh
   cocli user get users/u1/projects/p1 -o json
   ```
3. Actual：修复前，CLI 会把整个参数当成 user resource name，继续请求 `users/u1/projects/p1`。
4. Expected：`user get` 只应该接受 user id 或 `users/<user-id>`；多出来的 `/projects/p1` 应该被判定为无效 user resource name。

## 修复
- user ID 只匹配单个非空 path segment。
- 因此 `users/u1` 和 `users/current` 仍然合法；`users/u1/projects/p1`、`users/` 不再通过解析。

## 测试与 regression
- 新增测试覆盖多余路径和空 user ID。
- 普通 `users/u1`、`users/current` 解析保持不变。
- 已验证：`go test ./internal/name`、`go test ./pkg/cmd/user ./api`、`go test ./...`、`make lint`。
