### PR TITLE
[codex] clarify upload help

### DIFF
--- a/pkg/cmd/project/file.go
+++ b/pkg/cmd/project/file.go
@@ -350,8 +350,19 @@ func NewFileUploadCommand(cfgPath *string, io *iostreams.IOStreams, getProvider 
 	)
 
 	cmd := &cobra.Command{
-		Use:                   "upload <project-resource-name/slug> <path>... [--dir <target-dir>] [-H]",
-		Short:                 "Upload files or directory to a project",
+		Use:   "upload <project-resource-name/slug> <path>... [--dir <target-dir>] [-H]",
+		Short: "Upload files or directory to a project",
+		Long: `Upload one or more files or directories to a project.
+
+Each path can be a file, directory, or glob pattern. Directories are expanded
+recursively. Hidden files are skipped unless --include-hidden is set.
+
+The --parallel value is the maximum number of upload workers. For many small
+files, workers usually upload different files at the same time. For large files,
+workers may upload multipart parts from the same file.`,
+		Example: `  cocli project file upload <project-slug> ./data --parallel 8
+  cocli project file upload <project-slug> ./a ./b/file.mcap ./c --dir raw/
+  cocli project file upload <project-slug> ./data --no-tty`,
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -403,7 +414,7 @@ func NewFileUploadCommand(cfgPath *string, io *iostreams.IOStreams, getProvider 
 
 	cmd.Flags().BoolVarP(&includeHidden, "include-hidden", "H", false, "include hidden files (\"dot\" files) in the upload")
 	cmd.Flags().StringVarP(&targetDir, "dir", "d", "", "target directory in remote (e.g., 'backup/' to upload to backup/ subdirectory)")
-	cmd.Flags().IntVarP(&uploadManagerOpts.Threads, "parallel", "P", 4, "number of uploads (could be part) in parallel")
+	cmd.Flags().IntVarP(&uploadManagerOpts.Threads, "parallel", "P", 4, "maximum upload workers; small files upload as separate files, large files may upload as multipart parts")
 	cmd.Flags().StringVarP(&uploadManagerOpts.PartSize, "part-size", "s", "128Mib", "each part size")
 	cmd.Flags().BoolVar(&uploadManagerOpts.NoTTY, "no-tty", false, "disable interactive mode for headless environments")
 	cmd.Flags().BoolVar(&uploadManagerOpts.TTY, "tty", false, "force interactive mode even in headless environments")

--- a/pkg/cmd/project/project_test.go
+++ b/pkg/cmd/project/project_test.go
@@ -107,4 +107,29 @@ func TestProjectCommand(t *testing.T) {
 			assert.True(t, found, "File subcommand %s not found", expected)
 		}
 	})
+
+	t.Run("File upload help explains recursive multi-path parallel upload", func(t *testing.T) {
+		cfgPath := setupTestConfig(t)
+		var buf bytes.Buffer
+		io := iostreams.Test(nil, &buf, &buf)
+		cmd := project.NewRootCommand(&cfgPath, io, config.Provide)
+
+		uploadCmd, _, err := cmd.Find([]string{"file", "upload"})
+		require.NoError(t, err)
+
+		buf.Reset()
+		uploadCmd.SetOut(&buf)
+		uploadCmd.SetErr(&buf)
+		require.NoError(t, uploadCmd.Help())
+
+		help := buf.String()
+		assert.Contains(t, help, "Each path can be a file, directory, or glob pattern.")
+		assert.Contains(t, help, "Directories are expanded")
+		assert.Contains(t, help, "Hidden files are skipped unless --include-hidden is set.")
+		assert.Contains(t, help, "maximum number of upload workers")
+		assert.Contains(t, help, "different files at the same time")
+		assert.Contains(t, help, "multipart parts from the same file")
+		assert.Contains(t, help, "cocli project file upload <project-slug> ./data --parallel 8")
+		assert.Contains(t, help, "cocli project file upload <project-slug> ./a ./b/file.mcap ./c --dir raw/")
+	})
 }

--- a/pkg/cmd/record/record_test.go
+++ b/pkg/cmd/record/record_test.go
@@ -136,6 +136,31 @@ func TestRecordCommand(t *testing.T) {
 		assert.True(t, uploadCmd.Flag("no-tty") != nil && uploadCmd.Flag("tty") != nil)
 	})
 
+	t.Run("Upload command help explains recursive multi-path parallel upload", func(t *testing.T) {
+		cfgPath := setupTestConfig(t)
+		var buf bytes.Buffer
+		io := iostreams.Test(nil, &buf, &buf)
+		cmd := record.NewRootCommand(&cfgPath, io, config.Provide)
+
+		uploadCmd, _, err := cmd.Find([]string{"upload"})
+		require.NoError(t, err)
+
+		buf.Reset()
+		uploadCmd.SetOut(&buf)
+		uploadCmd.SetErr(&buf)
+		require.NoError(t, uploadCmd.Help())
+
+		help := buf.String()
+		assert.Contains(t, help, "Each path can be a file, directory, or glob pattern.")
+		assert.Contains(t, help, "Directories are expanded")
+		assert.Contains(t, help, "Hidden files are skipped unless --include-hidden is set.")
+		assert.Contains(t, help, "maximum number of upload workers")
+		assert.Contains(t, help, "different files at the same time")
+		assert.Contains(t, help, "multipart parts from the same file")
+		assert.Contains(t, help, "cocli record upload <record-id> ./data --parallel 8")
+		assert.Contains(t, help, "cocli record upload <record-id> ./a ./b/file.mcap ./c --dir raw/")
+	})
+
 	t.Run("Download command structure", func(t *testing.T) {
 		cfgPath := setupTestConfig(t)
 		var buf bytes.Buffer

--- a/pkg/cmd/record/upload.go
+++ b/pkg/cmd/record/upload.go
@@ -37,8 +37,19 @@ func NewUploadCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func
 	)
 
 	cmd := &cobra.Command{
-		Use:                   "upload <record-resource-name/id> <path>... [-p <working-project-slug>] [--dir <target-dir>] [-H]",
-		Short:                 "Upload files or directory to a record",
+		Use:   "upload <record-resource-name/id> <path>... [-p <working-project-slug>] [--dir <target-dir>] [-H]",
+		Short: "Upload files or directory to a record",
+		Long: `Upload one or more files or directories to a record.
+
+Each path can be a file, directory, or glob pattern. Directories are expanded
+recursively. Hidden files are skipped unless --include-hidden is set.
+
+The --parallel value is the maximum number of upload workers. For many small
+files, workers usually upload different files at the same time. For large files,
+workers may upload multipart parts from the same file.`,
+		Example: `  cocli record upload <record-id> ./data --parallel 8
+  cocli record upload <record-id> ./a ./b/file.mcap ./c --dir raw/
+  cocli record upload <record-id> ./data --no-tty`,
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -102,7 +113,7 @@ func NewUploadCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func
 	cmd.Flags().BoolVarP(&includeHidden, "include-hidden", "H", false, "include hidden files (\"dot\" files) in the upload")
 	cmd.Flags().StringVarP(&projectSlug, "project", "p", "", "the slug of the working project")
 	cmd.Flags().StringVarP(&targetDir, "dir", "d", "", "target directory in remote (e.g., 'backup/' to upload to backup/ subdirectory)")
-	cmd.Flags().IntVarP(&uploadManagerOpts.Threads, "parallel", "P", 4, "number of uploads (could be part) in parallel")
+	cmd.Flags().IntVarP(&uploadManagerOpts.Threads, "parallel", "P", 4, "maximum upload workers; small files upload as separate files, large files may upload as multipart parts")
 	cmd.Flags().StringVarP(&uploadManagerOpts.PartSize, "part-size", "s", "128Mib", "each part size")
 	cmd.Flags().DurationVar(&timeout, "response-timeout", 5*time.Minute, "server response time out")
 	cmd.Flags().BoolVar(&uploadManagerOpts.NoTTY, "no-tty", false, "disable interactive mode for headless environments")


### PR DESCRIPTION
## Summary
- Clarify that record/project upload accepts multiple paths and expands directories recursively.
- Explain that --parallel controls upload workers, which may upload separate small files or multipart parts for large files.
- Add help-output tests for both upload entry points.

## Validation
- go test ./pkg/cmd/record ./pkg/cmd/project
- go test ./...