### PR TITLE
Show project S3 connection info in coCLI

### DIFF
--- a/internal/printer/printable/project_s3_info.go
+++ b/internal/printer/printable/project_s3_info.go
@@ -1,0 +1,63 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package printable
+
+import (
+	"github.com/coscene-io/cocli/internal/printer/table"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// ProjectS3Info is the S3 connection information shown in project overview.
+type ProjectS3Info struct {
+	Endpoint string
+	Region   string
+	Bucket   string
+}
+
+func NewProjectS3Info(endpoint, region, bucket string) *ProjectS3Info {
+	return &ProjectS3Info{
+		Endpoint: endpoint,
+		Region:   region,
+		Bucket:   bucket,
+	}
+}
+
+func (i *ProjectS3Info) ToProtoMessage() proto.Message {
+	data, _ := structpb.NewStruct(map[string]any{
+		"endpoint": i.Endpoint,
+		"region":   i.Region,
+		"bucket":   i.Bucket,
+	})
+	return data
+}
+
+func (i *ProjectS3Info) ToTable(opts *table.PrintOpts) table.Table {
+	rows := [][]string{
+		{"ENDPOINT", i.Endpoint},
+		{"REGION", i.Region},
+		{"BUCKET", i.Bucket},
+	}
+
+	columnDefs := []table.ColumnDefinition{
+		{FieldName: "Field", TrimSize: 20},
+		{FieldName: "Value", TrimSize: 120},
+	}
+
+	return table.Table{
+		ColumnDefs: columnDefs,
+		Rows:       rows,
+	}
+}

--- a/internal/printer/printable/project_s3_info_test.go
+++ b/internal/printer/printable/project_s3_info_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package printable
+
+import (
+	"testing"
+
+	"github.com/coscene-io/cocli/internal/printer/table"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestProjectS3InfoToProtoMessage(t *testing.T) {
+	info := NewProjectS3Info("https://storage-cn-guangzhou.volc.coscene.cn", "cn-guangzhou", "coscene-hy.demo")
+	msg := info.ToProtoMessage()
+
+	st, ok := msg.(*structpb.Struct)
+	if !ok {
+		t.Fatalf("expected *structpb.Struct, got %T", msg)
+	}
+
+	if got := st.Fields["endpoint"].GetStringValue(); got != info.Endpoint {
+		t.Fatalf("endpoint = %q, want %q", got, info.Endpoint)
+	}
+	if got := st.Fields["region"].GetStringValue(); got != info.Region {
+		t.Fatalf("region = %q, want %q", got, info.Region)
+	}
+	if got := st.Fields["bucket"].GetStringValue(); got != info.Bucket {
+		t.Fatalf("bucket = %q, want %q", got, info.Bucket)
+	}
+}
+
+func TestProjectS3InfoToTable(t *testing.T) {
+	info := NewProjectS3Info("endpoint", "region", "bucket")
+	tbl := info.ToTable(&table.PrintOpts{})
+
+	if len(tbl.Rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(tbl.Rows))
+	}
+	if tbl.Rows[0][0] != "ENDPOINT" || tbl.Rows[0][1] != "endpoint" {
+		t.Fatalf("unexpected endpoint row: %#v", tbl.Rows[0])
+	}
+	if tbl.Rows[1][0] != "REGION" || tbl.Rows[1][1] != "region" {
+		t.Fatalf("unexpected region row: %#v", tbl.Rows[1])
+	}
+	if tbl.Rows[2][0] != "BUCKET" || tbl.Rows[2][1] != "bucket" {
+		t.Fatalf("unexpected bucket row: %#v", tbl.Rows[2])
+	}
+}

--- a/pkg/cmd/project/project_test.go
+++ b/pkg/cmd/project/project_test.go
@@ -43,7 +43,7 @@ func TestProjectCommand(t *testing.T) {
 		assert.Equal(t, "project", cmd.Use)
 		assert.NotEmpty(t, cmd.Short)
 
-		expectedSubcommands := []string{"list", "create", "file"}
+		expectedSubcommands := []string{"list", "create", "file", "s3-info"}
 
 		for _, expected := range expectedSubcommands {
 			found := false
@@ -106,5 +106,17 @@ func TestProjectCommand(t *testing.T) {
 			}
 			assert.True(t, found, "File subcommand %s not found", expected)
 		}
+	})
+
+	t.Run("S3 info command flags", func(t *testing.T) {
+		cfgPath := setupTestConfig(t)
+		var buf bytes.Buffer
+		io := iostreams.Test(nil, &buf, &buf)
+		cmd := project.NewRootCommand(&cfgPath, io, config.Provide)
+
+		s3InfoCmd, _, err := cmd.Find([]string{"s3-info"})
+		require.NoError(t, err)
+
+		assert.NotNil(t, s3InfoCmd.Flag("output"))
 	})
 }

--- a/pkg/cmd/project/root.go
+++ b/pkg/cmd/project/root.go
@@ -30,6 +30,7 @@ func NewRootCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 	cmd.AddCommand(NewListCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewCreateCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewFileCommand(cfgPath, io, getProvider))
+	cmd.AddCommand(NewS3InfoCommand(cfgPath, io, getProvider))
 	return cmd
 }
 

--- a/pkg/cmd/project/s3_info.go
+++ b/pkg/cmd/project/s3_info.go
@@ -1,0 +1,113 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import (
+	"context"
+	"strings"
+
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/internal/name"
+	"github.com/coscene-io/cocli/internal/printer"
+	"github.com/coscene-io/cocli/internal/printer/printable"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func NewS3InfoCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(string) config.Provider) *cobra.Command {
+	var outputFormat string
+
+	cmd := &cobra.Command{
+		Use:                   "s3-info [project-resource-name/slug]",
+		Short:                 "Show S3 connection information for a project",
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profile := pm.GetCurrentProfile()
+			projectName, err := resolveS3InfoProjectName(cmd.Context(), pm, args)
+			if err != nil {
+				log.Fatalf("unable to resolve project: %v", err)
+			}
+
+			project, err := pm.ProjectCli().Get(cmd.Context(), projectName)
+			if err != nil {
+				log.Fatalf("unable to get project: %v", err)
+			}
+
+			securityToken, err := pm.SecurityTokenCli().GenerateSecurityToken(cmd.Context(), projectName.String())
+			if err != nil {
+				log.Fatalf("unable to get S3 endpoint: %v", err)
+			}
+
+			endpoint := normalizeS3Endpoint(securityToken.GetEndpoint())
+			if endpoint == "" {
+				log.Fatalf("unable to get S3 endpoint: empty endpoint")
+			}
+
+			bucket := projectS3Bucket(profile.Org, project.GetSlug())
+			if bucket == "" {
+				log.Fatalf("unable to get S3 bucket: missing organization or project slug")
+			}
+
+			info := printable.NewProjectS3Info(endpoint, project.GetRegion(), bucket)
+			p, err := printer.Printer(outputFormat, &printer.Options{})
+			if err != nil {
+				log.Fatal(err)
+			}
+			if err = p.PrintObj(info, io.Out); err != nil {
+				log.Fatalf("unable to print S3 connection information: %v", err)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "output format (table|json|yaml)")
+
+	return cmd
+}
+
+func resolveS3InfoProjectName(ctx context.Context, pm *config.ProfileManager, args []string) (*name.Project, error) {
+	if len(args) == 0 || args[0] == "" {
+		return pm.ProjectName(ctx, "")
+	}
+	if strings.Contains(args[0], "/") {
+		projectName, err := name.NewProject(args[0])
+		if err != nil {
+			return nil, errors.Wrap(err, "parse project resource name")
+		}
+		return projectName, nil
+	}
+	return pm.ProjectName(ctx, args[0])
+}
+
+func normalizeS3Endpoint(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return ""
+	}
+	if strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
+		return endpoint
+	}
+	return "https://" + endpoint
+}
+
+func projectS3Bucket(orgSlug, projectSlug string) string {
+	if orgSlug == "" || projectSlug == "" {
+		return ""
+	}
+	return orgSlug + "." + projectSlug
+}

--- a/pkg/cmd/project/s3_info_test.go
+++ b/pkg/cmd/project/s3_info_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import "testing"
+
+func TestNormalizeS3Endpoint(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "host", in: "storage-cn-guangzhou.volc.coscene.cn", want: "https://storage-cn-guangzhou.volc.coscene.cn"},
+		{name: "shanghai host", in: "storage-cn-shanghai.coscene.cn", want: "https://storage-cn-shanghai.coscene.cn"},
+		{name: "us host", in: "storage-us-central-1.coscene.io", want: "https://storage-us-central-1.coscene.io"},
+		{name: "https", in: "https://storage-cn-guangzhou.volc.coscene.cn", want: "https://storage-cn-guangzhou.volc.coscene.cn"},
+		{name: "http", in: "http://localhost:9000", want: "http://localhost:9000"},
+		{name: "trim", in: " storage-cn-hangzhou.coscene.cn ", want: "https://storage-cn-hangzhou.coscene.cn"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeS3Endpoint(tt.in); got != tt.want {
+				t.Fatalf("normalizeS3Endpoint(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectS3Bucket(t *testing.T) {
+	tests := []struct {
+		name        string
+		orgSlug     string
+		projectSlug string
+		want        string
+	}{
+		{name: "normal", orgSlug: "coscene-hy", projectSlug: "demo", want: "coscene-hy.demo"},
+		{name: "short project", orgSlug: "coscene-fei-shu", projectSlug: "cs", want: "coscene-fei-shu.cs"},
+		{name: "hyphenated", orgSlug: "tii-humanoids", projectSlug: "ego-c", want: "tii-humanoids.ego-c"},
+		{name: "empty org", orgSlug: "", projectSlug: "demo", want: ""},
+		{name: "empty project", orgSlug: "coscene-hy", projectSlug: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := projectS3Bucket(tt.orgSlug, tt.projectSlug); got != tt.want {
+				t.Fatalf("projectS3Bucket(%q, %q) = %q, want %q", tt.orgSlug, tt.projectSlug, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add `cocli project s3-info` to print endpoint, region, and bucket for a project
- match the project overview S3 bucket format (`<org-slug>.<project-slug>`)
- use the public storage token endpoint only to discover the S3 gateway endpoint; do not print credentials

## Validation
- `go test ./...`
- `go run ./cmd/cocli project s3-info -o json`
- `go run ./cmd/cocli project s3-info demo`