### PR TITLE
fix: upload progress exceeding 100% due to minio SDK retries

### DIFF
--- a/pkg/cmd_utils/upload_utils/upload_manager.go
+++ b/pkg/cmd_utils/upload_utils/upload_manager.go
@@ -1158,6 +1158,7 @@ func tick() tea.Cmd {
 type uploadProgressReader struct {
 	*os.File
 	fileInfo   *FileInfo
+	uploaded   int64
 	progressCh chan IncUploadedMsg
 }
 
@@ -1166,15 +1167,34 @@ func (r *uploadProgressReader) Read(b []byte) (int, error) {
 	if err != nil && err != io.EOF {
 		r.progressCh <- IncUploadedMsg{
 			Path:        r.fileInfo.Path,
-			UploadedInc: -r.fileInfo.Uploaded,
+			UploadedInc: -r.uploaded,
 		}
+		r.uploaded = 0
 	} else {
 		r.progressCh <- IncUploadedMsg{
 			Path:        r.fileInfo.Path,
 			UploadedInc: int64(n),
 		}
+		r.uploaded += int64(n)
 	}
 	return n, err
+}
+
+func (r *uploadProgressReader) Seek(offset int64, whence int) (int64, error) {
+	pos, err := r.File.Seek(offset, whence)
+	if err != nil {
+		return pos, err
+	}
+	// When seeking back (the minio SDK seeks to 0 on retry), undo the
+	// progress counted so far so that the re-read does not double-count.
+	if whence == 0 && offset == 0 && r.uploaded > 0 {
+		r.progressCh <- IncUploadedMsg{
+			Path:        r.fileInfo.Path,
+			UploadedInc: -r.uploaded,
+		}
+		r.uploaded = 0
+	}
+	return pos, nil
 }
 
 // uploadProgressSectionReader is a SectionReader that also sends progress updates to a channel.
@@ -1201,6 +1221,23 @@ func (r *uploadProgressSectionReader) Read(b []byte) (int, error) {
 		r.uploaded += int64(n)
 	}
 	return n, err
+}
+
+func (r *uploadProgressSectionReader) Seek(offset int64, whence int) (int64, error) {
+	pos, err := r.SectionReader.Seek(offset, whence)
+	if err != nil {
+		return pos, err
+	}
+	// When seeking back (the minio SDK seeks to 0 on retry), undo the
+	// progress counted so far so that the re-read does not double-count.
+	if whence == 0 && offset == 0 && r.uploaded > 0 {
+		r.progressCh <- IncUploadedMsg{
+			Path:        r.fileInfo.Path,
+			UploadedInc: -r.uploaded,
+		}
+		r.uploaded = 0
+	}
+	return pos, nil
 }
 
 // nonInteractiveProgressReporter reports progress in non-interactive mode

--- a/pkg/cmd_utils/upload_utils/upload_manager_test.go
+++ b/pkg/cmd_utils/upload_utils/upload_manager_test.go
@@ -15,6 +15,10 @@
 package upload_utils
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -134,4 +138,151 @@ func TestUploadManager_View(t *testing.T) {
 		u := model.(*UploadManager)
 		assert.Equal(t, 120, u.windowWidth)
 	})
+}
+
+// collectProgress drains the progress channel and returns the net sum of UploadedInc.
+func collectProgress(ch chan IncUploadedMsg) int64 {
+	var total int64
+	for {
+		select {
+		case msg := <-ch:
+			total += msg.UploadedInc
+		default:
+			return total
+		}
+	}
+}
+
+// TestUploadProgressSectionReader_SeekRetryDoesNotDoubleCount reproduces the
+// upload-progress-exceeds-100% bug. The minio SDK retries failed PUT requests
+// by calling Seek(0, 0) on the reader and re-reading. Before the fix, the
+// progress reader did not override Seek, so re-read bytes were double-counted.
+func TestUploadProgressSectionReader_SeekRetryDoesNotDoubleCount(t *testing.T) {
+	data := bytes.Repeat([]byte("x"), 1000)
+	sectionReader := io.NewSectionReader(bytes.NewReader(data), 0, int64(len(data)))
+
+	progressCh := make(chan IncUploadedMsg, 1000)
+	fi := &FileInfo{Path: "test.dat", Size: int64(len(data))}
+
+	reader := &uploadProgressSectionReader{
+		SectionReader: sectionReader,
+		fileInfo:      fi,
+		progressCh:    progressCh,
+	}
+
+	// 1. First read: read all data (simulates first upload attempt)
+	buf := make([]byte, len(data))
+	_, err := io.ReadFull(reader, buf)
+	require.NoError(t, err)
+
+	firstPass := collectProgress(progressCh)
+	assert.Equal(t, int64(len(data)), firstPass, "progress should equal data size after first read")
+
+	// 2. Simulate minio SDK retry: seek back to 0
+	_, err = reader.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+
+	seekCorrection := collectProgress(progressCh)
+	assert.Equal(t, -int64(len(data)), seekCorrection,
+		"Seek(0,0) must send a negative correction equal to data size")
+
+	// 3. Second read (retry): read all data again
+	_, err = io.ReadFull(reader, buf)
+	require.NoError(t, err)
+
+	retryPass := collectProgress(progressCh)
+	assert.Equal(t, int64(len(data)), retryPass, "progress should equal data size after retry read")
+
+	// Total across the entire retry cycle must equal exactly data size.
+	total := firstPass + seekCorrection + retryPass
+	assert.Equal(t, int64(len(data)), total,
+		"total progress should be data size, not 2×data size")
+}
+
+// TestUploadProgressSectionReader_MultipleRetries ensures progress stays
+// bounded even after several consecutive seek+re-read cycles.
+func TestUploadProgressSectionReader_MultipleRetries(t *testing.T) {
+	data := bytes.Repeat([]byte("x"), 1000)
+	sectionReader := io.NewSectionReader(bytes.NewReader(data), 0, int64(len(data)))
+
+	progressCh := make(chan IncUploadedMsg, 10000)
+	fi := &FileInfo{Path: "test.dat", Size: int64(len(data))}
+
+	reader := &uploadProgressSectionReader{
+		SectionReader: sectionReader,
+		fileInfo:      fi,
+		progressCh:    progressCh,
+	}
+
+	buf := make([]byte, len(data))
+
+	// Simulate 5 retries (minio SDK maxRetry = 10)
+	for i := 0; i < 5; i++ {
+		_, err := io.ReadFull(reader, buf)
+		require.NoError(t, err)
+
+		_, err = reader.Seek(0, io.SeekStart)
+		require.NoError(t, err)
+	}
+	// One final successful read (no seek after)
+	_, err := io.ReadFull(reader, buf)
+	require.NoError(t, err)
+
+	// Drain all remaining messages
+	var totalProgress int64
+	for len(progressCh) > 0 {
+		msg := <-progressCh
+		totalProgress += msg.UploadedInc
+	}
+
+	assert.Equal(t, int64(len(data)), totalProgress,
+		"after 5 retries + 1 final read, progress should equal data size, not 6×data size")
+}
+
+// TestUploadProgressReader_SeekRetryDoesNotDoubleCount is the same test
+// for the single-upload (*os.File based) progress reader.
+func TestUploadProgressReader_SeekRetryDoesNotDoubleCount(t *testing.T) {
+	data := bytes.Repeat([]byte("x"), 1000)
+	tmpFile := filepath.Join(t.TempDir(), "test.dat")
+	err := os.WriteFile(tmpFile, data, 0644)
+	require.NoError(t, err)
+
+	f, err := os.Open(tmpFile)
+	require.NoError(t, err)
+	defer f.Close()
+
+	progressCh := make(chan IncUploadedMsg, 1000)
+	fi := &FileInfo{Path: tmpFile, Size: int64(len(data))}
+
+	reader := &uploadProgressReader{
+		File:       f,
+		fileInfo:   fi,
+		progressCh: progressCh,
+	}
+
+	// 1. First read
+	buf := make([]byte, len(data))
+	_, err = io.ReadFull(reader, buf)
+	require.NoError(t, err)
+
+	firstPass := collectProgress(progressCh)
+	assert.Equal(t, int64(len(data)), firstPass)
+
+	// 2. Seek back (SDK retry)
+	_, err = reader.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+
+	seekCorrection := collectProgress(progressCh)
+	assert.Equal(t, -int64(len(data)), seekCorrection)
+
+	// 3. Re-read
+	_, err = io.ReadFull(reader, buf)
+	require.NoError(t, err)
+
+	retryPass := collectProgress(progressCh)
+	assert.Equal(t, int64(len(data)), retryPass)
+
+	total := firstPass + seekCorrection + retryPass
+	assert.Equal(t, int64(len(data)), total,
+		"total progress should equal data size, not double-count")
 }

--- a/pkg/cmd_utils/upload_utils/upload_manager_test.go
+++ b/pkg/cmd_utils/upload_utils/upload_manager_test.go
@@ -249,7 +249,7 @@ func TestUploadProgressReader_SeekRetryDoesNotDoubleCount(t *testing.T) {
 
 	f, err := os.Open(tmpFile)
 	require.NoError(t, err)
-	defer f.Close()
+	defer func() { require.NoError(t, f.Close()) }()
 
 	progressCh := make(chan IncUploadedMsg, 1000)
 	fi := &FileInfo{Path: tmpFile, Size: int64(len(data))}


### PR DESCRIPTION
## Summary

- Fix upload progress exceeding 100% (observed up to ~220%) in `cocli upload`
- Root cause: minio-go SDK retries failed uploads by calling `Seek(0, 0)` on the reader, then re-reading. Both `uploadProgressReader` and `uploadProgressSectionReader` embed seekable types (`*os.File`, `*io.SectionReader`), so the SDK treats them as retryable. Since neither overrode `Seek`, re-read bytes were double-counted.
- Fix: override `Seek` on both readers to send a negative progress correction before the underlying seek, preventing double-counting. Also fix `uploadProgressReader`'s error branch to use a local counter instead of the shared `fileInfo.Uploaded` pointer.

## Test plan

- [x] `TestUploadProgressSectionReader_SeekRetryDoesNotDoubleCount` — simulates one minio retry cycle (read → seek → re-read), verifies total progress equals data size
- [x] `TestUploadProgressSectionReader_MultipleRetries` — simulates 5 consecutive retries, verifies progress stays bounded
- [x] `TestUploadProgressReader_SeekRetryDoesNotDoubleCount` — same test for the single-upload (`*os.File`) progress reader
- [x] All 32 existing tests in `upload_utils` pass