### PR TITLE
Add tests for force-quit signal handling

### DIFF
--- a/cmd/cocli/main.go
+++ b/cmd/cocli/main.go
@@ -58,12 +58,10 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	go func() {
-		<-ctx.Done() // first signal: graceful cancel requested
-		<-forceQuitSignals()
+	go watchForceQuit(ctx, forceQuitSignals(), func() {
 		sentry.Flush(500 * time.Millisecond) // bounded — user is force-quitting
 		os.Exit(130)                         // second signal: force quit (128 + SIGINT)
-	}()
+	})
 
 	if err := cmd.NewCommand(io, config.Provide).ExecuteContext(ctx); err != nil {
 		io.Println(err)
@@ -80,6 +78,15 @@ func forceQuitSignals() <-chan os.Signal {
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 	return ch
+}
+
+// watchForceQuit blocks until the context is cancelled (first signal) and then
+// a value arrives on quit (second signal), at which point onForceQuit is invoked.
+// Extracted from main for testability — the production callback calls os.Exit.
+func watchForceQuit(ctx context.Context, quit <-chan os.Signal, onForceQuit func()) {
+	<-ctx.Done() // first signal: graceful cancel requested
+	<-quit       // second signal: user insists
+	onForceQuit()
 }
 
 func newSentryClientOptions() sentry.ClientOptions {

--- a/cmd/cocli/main_test.go
+++ b/cmd/cocli/main_test.go
@@ -15,7 +15,10 @@
 package main
 
 import (
+	"context"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/coscene-io/cocli"
 )
@@ -34,5 +37,39 @@ func TestNewSentryClientOptions(t *testing.T) {
 	}
 	if !opts.AttachStacktrace {
 		t.Fatalf("expected AttachStacktrace to be true")
+	}
+}
+
+func TestForceQuitSignals(t *testing.T) {
+	ch := forceQuitSignals()
+	if ch == nil {
+		t.Fatal("expected non-nil channel")
+	}
+	if cap(ch) != 1 {
+		t.Fatalf("expected buffered channel of cap 1, got cap %d", cap(ch))
+	}
+}
+
+func TestWatchForceQuit_InvokesCallbackAfterSecondSignal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	quit := make(chan os.Signal, 1)
+	done := make(chan struct{})
+
+	go watchForceQuit(ctx, quit, func() { close(done) })
+
+	// First signal: cancel the context. Callback must NOT fire yet.
+	cancel()
+	select {
+	case <-done:
+		t.Fatal("callback fired after first signal; expected it to wait for the second")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Second signal: deliver on quit. Callback must fire.
+	quit <- os.Interrupt
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("callback did not fire after second signal")
 	}
 }


### PR DESCRIPTION
## What

Follow-up to #175. That PR's signal-handling code had 0% patch coverage because the force-quit goroutine body was inline in `main()` and ended in `os.Exit` — process-level, not unit-testable.

This extracts `watchForceQuit(ctx, quit, onForceQuit)` so the wait-for-second-signal logic is testable with an injected quit channel and callback (production callback still calls `os.Exit`). Adds tests:

- `TestWatchForceQuit_InvokesCallbackAfterSecondSignal` — verifies the callback fires only after BOTH the context cancellation (first signal) and a value on the quit channel (second signal), not after the first alone.
- `TestForceQuitSignals` — verifies the returned channel is buffered (cap 1).

`cmd/cocli` coverage: 0% → 25.9%. No behavior change.

## Note

codecov has `patch: off`, so this was non-blocking, but the signal path is worth locking in with a regression test.