### PR TITLE
feat(config): accept env-scoped openapi endpoint for shared dev hosts

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,6 +42,10 @@ func TestProfile_Validate(t *testing.T) {
 			wantErr: "endpoint should start with https://openapi.",
 		},
 		{
+			name:    "valid env-scoped endpoint",
+			profile: &Profile{Name: "dev", EndPoint: "https://openapi-e2e.dev.example.com", Token: "tok", ProjectSlug: "proj"},
+		},
+		{
 			name:    "empty token",
 			profile: &Profile{Name: "dev", EndPoint: "https://openapi.dev.coscene.cn", Token: "", ProjectSlug: "proj"},
 			wantErr: "token cannot be empty",

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -90,7 +90,13 @@ func (p *Profile) Validate() error {
 	if p.Name == "" {
 		return errors.Errorf("profile name cannot be empty")
 	}
-	if !strings.HasPrefix(p.EndPoint, "https://openapi.") {
+	// Endpoints address the public openapi gateway. The canonical form is
+	// `https://openapi.<base>`; shared dev hosts give each env its own
+	// gateway subdomain prefixed with the env name
+	// (`https://openapi-<env>.<base>`). Accept either — the leading host
+	// label must be `openapi` or `openapi-<env>`.
+	if !strings.HasPrefix(p.EndPoint, "https://openapi.") &&
+		!strings.HasPrefix(p.EndPoint, "https://openapi-") {
 		return errors.Errorf("profile %s's endpoint should start with https://openapi.", p.Name)
 	}
 	if p.Token == "" {


### PR DESCRIPTION
## Why

The profile validator only accepted the canonical openapi gateway host (`https://openapi.<base>`). Shared dev hosts give each env its own gateway subdomain prefixed with the env name — `https://openapi-<env>.<base>` — so cocli couldn't target an env-scoped gateway directly (`endpoint should start with https://openapi.`).

## Change

Accept either form — the leading host label must be `openapi` or `openapi-<env>`. Domain-agnostic; no environment hostnames baked in. Added positive test coverage.

## Context

Pairs with an integration-tests nginx fix (forward client Host as gRPC `:authority`) that makes env-scoped gateway subdomains routable. Together they enable off-substrate / host-side cocli against shared dev hosts.