### PR TITLE
feat(action logs): download archived log for finished job runs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/coscene-io/cocli
 go 1.25.0
 
 require (
-	buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260622052127-abdaecb8392d.1
-	buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260622052127-abdaecb8392d.1
+	buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260622125952-8be5fbcdb2b5.1
+	buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260622125952-8be5fbcdb2b5.1
 	connectrpc.com/connect v1.20.0
 	dario.cat/mergo v1.0.2
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20240508200655-46a4cf4ba109.1 h1:NXwdBG3BiC6xWH4iG3csbT+JHF9u1jl5ThDhumCnKnk=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20240508200655-46a4cf4ba109.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
-buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260622052127-abdaecb8392d.1 h1:HNKy+eIk7JV7hINePEuXGdPHH3oJuYJEKBaHrdSJ3kM=
-buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260622052127-abdaecb8392d.1/go.mod h1:g5n203yhrK5eLLbuRYMGNDCray6FCV5mHZ3vCMtzOPU=
-buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260622052127-abdaecb8392d.1 h1:ESTvil1RD47NIkuNVLFMneg+vxdHH52qF+IxXH5dQb0=
-buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260622052127-abdaecb8392d.1/go.mod h1:ncUQjVNWzogYkhgQ1XinFjWE1h7HuPtKpimyf90abE0=
+buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260622125952-8be5fbcdb2b5.1 h1:FkD9XqiTRajv3APfGS5wifxokp9aknarJahLhCPUVLo=
+buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260622125952-8be5fbcdb2b5.1/go.mod h1:ZnIMRWoJw0ssLl1J81y2N5GQrRWupU7c/KOA8nYh8rg=
+buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260622125952-8be5fbcdb2b5.1 h1:d7O8CUug2CoMxrcd21ksEcrItZgMY5+gbiXy53w6Uis=
+buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260622125952-8be5fbcdb2b5.1/go.mod h1:ncUQjVNWzogYkhgQ1XinFjWE1h7HuPtKpimyf90abE0=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.11-20230414000709-087bc8072ce4.1 h1:t8f+WWZ5WNrZaP5zrpWD8f1tKU7eelJMbIAT9FRX558=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.11-20230414000709-087bc8072ce4.1/go.mod h1:/t9AeRQQp2iNkiGHDLfHLW3SzNpYpNPGRZ+Ih8+SOUs=
 connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=

--- a/pkg/cmd/action/logs.go
+++ b/pkg/cmd/action/logs.go
@@ -24,6 +24,7 @@ import (
 
 	openv1alpha1enums "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/enums"
 	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	openv1alpha1service "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/services"
 	"connectrpc.com/connect"
 	"github.com/coscene-io/cocli/api"
 	"github.com/coscene-io/cocli/internal/config"
@@ -47,8 +48,33 @@ func NewLogsCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 	)
 
 	cmd := &cobra.Command{
-		Use:                   "logs <action-run-name/id> [-j <job-index>] [--node <node>] [-f] [-p <working-project-slug>]",
-		Short:                 "Stream logs of an action run's job run",
+		Use:   "logs <action-run-name/id> [-j <job-index>] [--node <node>] [-f] [-p <working-project-slug>]",
+		Short: "Stream logs of an action run's job run",
+		Long: `Stream the logs of an action run's job run.
+
+The action run is given as a full resource name
+(projects/<project>/actionRuns/<uuid>) or a bare UUID.
+
+While the job run is running, its pod logs are streamed live. Once the job
+run has finished and its pod has been cleaned up, the archived log is
+downloaded and printed instead — so the command works the same regardless
+of whether the run is in progress or already completed.
+
+  -j  select which job run to read when an action run has several
+      (default 0 = the first).
+  --node  select a node to read for multi-node (DAG) job runs; not needed
+      for single-step jobs.
+  -f  follow: keep the stream open and reconnect on transient errors. If
+      the job run has not started yet, wait for it to start. Without -f, a
+      not-yet-started run is reported and the command exits.`,
+		Example: `  # Print logs for a finished or running action run (first job run)
+  cocli action logs projects/my-project/actionRuns/<uuid> -p my-project
+
+  # By bare UUID, following a running job and waiting if it hasn't started
+  cocli action logs <uuid> -p my-project -f
+
+  # A specific job run and DAG node
+  cocli action logs <uuid> -p my-project -j 1 --node encode`,
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -277,16 +303,22 @@ func streamOnce(ctx context.Context, cli api.JobRunInterface, jobRunName, node s
 	defer func() { _ = stream.Close() }()
 
 	for stream.Receive() {
-		msg := stream.Msg()
-		if downloadURL := msg.GetLogDownloadUri(); downloadURL != "" {
-			if err = printArchivedLog(ctx, downloadURL, io); err != nil {
-				return err
-			}
-			continue
+		if err = handleLogMessage(ctx, stream.Msg(), io); err != nil {
+			return err
 		}
-		io.Println(msg.GetMessage())
 	}
 	return stream.Err()
+}
+
+// handleLogMessage renders one LogJobRun response: a live log line (message),
+// or — for a finished job run — a presigned URL (log_download_uri) whose
+// archived log is downloaded and printed.
+func handleLogMessage(ctx context.Context, msg *openv1alpha1service.LogJobRunResponse, io *iostreams.IOStreams) error {
+	if downloadURL := msg.GetLogDownloadUri(); downloadURL != "" {
+		return printArchivedLog(ctx, downloadURL, io)
+	}
+	io.Println(msg.GetMessage())
+	return nil
 }
 
 // printArchivedLog downloads the archived job-run log from the presigned URL the

--- a/pkg/cmd/action/logs.go
+++ b/pkg/cmd/action/logs.go
@@ -301,6 +301,13 @@ func printArchivedLog(ctx context.Context, downloadURL string, io *iostreams.IOS
 		return fmt.Errorf("download archived log: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		// The job run finished but no log was archived (e.g. the pod produced
+		// none, or archival wasn't enabled when it ran). Report cleanly rather
+		// than surfacing a raw 404.
+		io.Println("No logs available for this job run.")
+		return nil
+	}
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("download archived log: unexpected status %d", resp.StatusCode)
 	}

--- a/pkg/cmd/action/logs.go
+++ b/pkg/cmd/action/logs.go
@@ -15,9 +15,11 @@
 package action
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
@@ -189,6 +191,10 @@ func followLogs(
 }
 
 // streamOnce opens a single log stream and relays lines until it ends or errors.
+// A running job streams live log lines (message). A finished job whose pod has
+// been garbage collected has no live logs; the server then sends a single
+// response carrying a presigned URL for the archived log, which we download and
+// print so `action logs` works transparently regardless of job state.
 func streamOnce(ctx context.Context, cli api.JobRunInterface, jobRunName, node string, io *iostreams.IOStreams) error {
 	stream, err := cli.LogJobRun(ctx, jobRunName, node)
 	if err != nil {
@@ -197,9 +203,46 @@ func streamOnce(ctx context.Context, cli api.JobRunInterface, jobRunName, node s
 	defer func() { _ = stream.Close() }()
 
 	for stream.Receive() {
-		io.Println(stream.Msg().GetMessage())
+		msg := stream.Msg()
+		if downloadURL := msg.GetLogDownloadUri(); downloadURL != "" {
+			if err = printArchivedLog(ctx, downloadURL, io); err != nil {
+				return err
+			}
+			continue
+		}
+		io.Println(msg.GetMessage())
 	}
 	return stream.Err()
+}
+
+// printArchivedLog downloads the archived job-run log from the presigned URL the
+// server returned and writes it to stdout, line by line.
+func printArchivedLog(ctx context.Context, downloadURL string, io *iostreams.IOStreams) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return fmt.Errorf("build archived log request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("download archived log: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download archived log: unexpected status %d", resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	// Job logs can carry long lines (stack traces, serialized payloads); raise
+	// the token cap well above bufio's 64KiB default.
+	const maxLogLineBytes = 4 * 1024 * 1024
+	scanner.Buffer(make([]byte, 0, 64*1024), maxLogLineBytes)
+	for scanner.Scan() {
+		io.Println(scanner.Text())
+	}
+	if err = scanner.Err(); err != nil {
+		return fmt.Errorf("read archived log: %w", err)
+	}
+	return nil
 }
 
 // resolveDefaultNode picks a node name when the job run is a multi-node DAG.

--- a/pkg/cmd/action/logs.go
+++ b/pkg/cmd/action/logs.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"time"
 
+	openv1alpha1enums "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/enums"
 	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
 	"connectrpc.com/connect"
 	"github.com/coscene-io/cocli/api"
@@ -75,6 +76,23 @@ func NewLogsCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 
 			cli := pm.JobRunCli()
 			jobRunName := jobRun.GetName()
+
+			// A job run that hasn't started yet (queued/scheduling) has no
+			// pod to stream and no archived log to download. Wait for it to
+			// start when following; otherwise report and exit cleanly rather
+			// than appearing to "finish" with no output.
+			started, err := awaitJobRunStart(cmd.Context(), cli, jobRunName, jobRun.GetState(), follow, io)
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+				exitf(io, "%v", err)
+				return
+			}
+			if !started {
+				return
+			}
+
 			streamFn := func(ctx context.Context, n string) error {
 				return streamOnce(ctx, cli, jobRunName, n, io)
 			}
@@ -142,6 +160,62 @@ func listJobRunsWithWait(ctx context.Context, cli api.JobRunInterface, actionRun
 		io.Eprintln(fmt.Sprintf("Waiting for job runs... (attempt %d/%d)", attempt+1, reconnectMaxAttempts))
 		if err = sleepCtx(ctx, delay); err != nil {
 			return nil, err
+		}
+		delay = nextDelay(delay)
+	}
+}
+
+// jobRunNotStarted reports whether a job run has not begun executing yet
+// (queued/scheduling/unspecified) — no pod exists to stream and no log has
+// been archived.
+func jobRunNotStarted(state openv1alpha1enums.JobRunStateEnum_JobRunState) bool {
+	switch state {
+	case openv1alpha1enums.JobRunStateEnum_JOB_RUN_STATE_UNSPECIFIED,
+		openv1alpha1enums.JobRunStateEnum_QUEUED,
+		openv1alpha1enums.JobRunStateEnum_SCHEDULING:
+		return true
+	default:
+		return false
+	}
+}
+
+// awaitJobRunStart blocks until a not-yet-started job run begins (running or
+// terminal) when follow is set, polling its state. Without follow it reports
+// the state and returns started=false so the caller exits cleanly instead of
+// treating an empty stream as a finished job. Returns started=true immediately
+// when the run has already started.
+func awaitJobRunStart(
+	ctx context.Context,
+	cli api.JobRunInterface,
+	jobRunName string,
+	state openv1alpha1enums.JobRunStateEnum_JobRunState,
+	follow bool,
+	io *iostreams.IOStreams,
+) (bool, error) {
+	if !jobRunNotStarted(state) {
+		return true, nil
+	}
+	if !follow {
+		io.Println(fmt.Sprintf(
+			"Job run has not started yet (state: %s). Pass -f to wait for logs.",
+			state.String(),
+		))
+		return false, nil
+	}
+
+	delay := reconnectBaseDelay
+	for {
+		io.Eprintln(fmt.Sprintf("Waiting for job run to start (state: %s)...", state.String()))
+		if err := sleepCtx(ctx, delay); err != nil {
+			return false, err
+		}
+		jobRun, err := cli.GetJobRun(ctx, jobRunName)
+		if err != nil {
+			return false, err
+		}
+		state = jobRun.GetState()
+		if !jobRunNotStarted(state) {
+			return true, nil
 		}
 		delay = nextDelay(delay)
 	}

--- a/pkg/cmd/action/logs_test.go
+++ b/pkg/cmd/action/logs_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	openv1alpha1enums "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/enums"
 	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
 	openv1alpha1service "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/services"
 	"connectrpc.com/connect"
@@ -58,6 +59,62 @@ func discardIO() *iostreams.IOStreams {
 type discardWriter struct{}
 
 func (*discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func TestJobRunNotStarted(t *testing.T) {
+	notStarted := []openv1alpha1enums.JobRunStateEnum_JobRunState{
+		openv1alpha1enums.JobRunStateEnum_JOB_RUN_STATE_UNSPECIFIED,
+		openv1alpha1enums.JobRunStateEnum_QUEUED,
+		openv1alpha1enums.JobRunStateEnum_SCHEDULING,
+	}
+	for _, s := range notStarted {
+		if !jobRunNotStarted(s) {
+			t.Errorf("state %s should be not-started", s.String())
+		}
+	}
+	started := []openv1alpha1enums.JobRunStateEnum_JobRunState{
+		openv1alpha1enums.JobRunStateEnum_RUNNING,
+		openv1alpha1enums.JobRunStateEnum_SUCCEEDED,
+		openv1alpha1enums.JobRunStateEnum_FAILED,
+		openv1alpha1enums.JobRunStateEnum_ABORTED,
+	}
+	for _, s := range started {
+		if jobRunNotStarted(s) {
+			t.Errorf("state %s should be started", s.String())
+		}
+	}
+}
+
+func TestAwaitJobRunStart_AlreadyStarted(t *testing.T) {
+	started, err := awaitJobRunStart(context.Background(), &fakeJobRunClient{}, "jr",
+		openv1alpha1enums.JobRunStateEnum_RUNNING, true, discardIO())
+	if err != nil || !started {
+		t.Fatalf("running job should be started immediately: started=%v err=%v", started, err)
+	}
+}
+
+func TestAwaitJobRunStart_NoFollowReports(t *testing.T) {
+	started, err := awaitJobRunStart(context.Background(), &fakeJobRunClient{}, "jr",
+		openv1alpha1enums.JobRunStateEnum_QUEUED, false, discardIO())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if started {
+		t.Fatal("queued job without follow should not be started")
+	}
+}
+
+func TestAwaitJobRunStart_FollowCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled before the first wait
+	started, err := awaitJobRunStart(ctx, &fakeJobRunClient{}, "jr",
+		openv1alpha1enums.JobRunStateEnum_QUEUED, true, discardIO())
+	if started {
+		t.Fatal("expected not started on canceled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
 
 func TestFollowLogs_CleanEnd(t *testing.T) {
 	calls := 0

--- a/pkg/cmd/action/logs_test.go
+++ b/pkg/cmd/action/logs_test.go
@@ -15,7 +15,11 @@
 package action
 
 import (
+	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,6 +38,10 @@ type fakeJobRunClient struct {
 	listErr    error
 	dag        *openv1alpha1resource.JobRunDag
 	dagErr     error
+	// getQueue is popped one entry per GetJobRun call (last entry repeats);
+	// getErr is returned instead when set.
+	getQueue []*openv1alpha1resource.JobRun
+	getErr   error
 }
 
 func (f *fakeJobRunClient) ListJobRuns(_ context.Context, _ *name.ActionRun) ([]*openv1alpha1resource.JobRun, error) {
@@ -41,7 +49,17 @@ func (f *fakeJobRunClient) ListJobRuns(_ context.Context, _ *name.ActionRun) ([]
 }
 
 func (f *fakeJobRunClient) GetJobRun(_ context.Context, _ string) (*openv1alpha1resource.JobRun, error) {
-	return nil, nil
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if len(f.getQueue) == 0 {
+		return &openv1alpha1resource.JobRun{}, nil
+	}
+	jr := f.getQueue[0]
+	if len(f.getQueue) > 1 {
+		f.getQueue = f.getQueue[1:]
+	}
+	return jr, nil
 }
 
 func (f *fakeJobRunClient) GetJobRunDag(_ context.Context, _ string) (*openv1alpha1resource.JobRunDag, error) {
@@ -59,6 +77,57 @@ func discardIO() *iostreams.IOStreams {
 type discardWriter struct{}
 
 func (*discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func TestPrintArchivedLog_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("line-one\nline-two\n"))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	io := iostreams.Test(nil, &out, &discardWriter{})
+	if err := printArchivedLog(context.Background(), srv.URL, io); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "line-one") || !strings.Contains(got, "line-two") {
+		t.Fatalf("archived log not printed: %q", got)
+	}
+}
+
+func TestPrintArchivedLog_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	err := printArchivedLog(context.Background(), srv.URL, discardIO())
+	if err == nil || !strings.Contains(err.Error(), "unexpected status") {
+		t.Fatalf("expected non-200 error, got %v", err)
+	}
+}
+
+func TestAwaitJobRunStart_FollowPollsUntilRunning(t *testing.T) {
+	cli := &fakeJobRunClient{
+		getQueue: []*openv1alpha1resource.JobRun{
+			{State: openv1alpha1enums.JobRunStateEnum_RUNNING},
+		},
+	}
+	started, err := awaitJobRunStart(context.Background(), cli, "jr",
+		openv1alpha1enums.JobRunStateEnum_QUEUED, true, discardIO())
+	if err != nil || !started {
+		t.Fatalf("expected started after poll: started=%v err=%v", started, err)
+	}
+}
+
+func TestAwaitJobRunStart_FollowGetError(t *testing.T) {
+	cli := &fakeJobRunClient{getErr: errors.New("boom")}
+	started, err := awaitJobRunStart(context.Background(), cli, "jr",
+		openv1alpha1enums.JobRunStateEnum_QUEUED, true, discardIO())
+	if started || err == nil {
+		t.Fatalf("expected error from GetJobRun: started=%v err=%v", started, err)
+	}
+}
 
 func TestJobRunNotStarted(t *testing.T) {
 	notStarted := []openv1alpha1enums.JobRunStateEnum_JobRunState{

--- a/pkg/cmd/action/logs_test.go
+++ b/pkg/cmd/action/logs_test.go
@@ -78,6 +78,37 @@ type discardWriter struct{}
 
 func (*discardWriter) Write(p []byte) (int, error) { return len(p), nil }
 
+func TestHandleLogMessage_LiveLine(t *testing.T) {
+	var out bytes.Buffer
+	io := iostreams.Test(nil, &out, &discardWriter{})
+	err := handleLogMessage(context.Background(),
+		&openv1alpha1service.LogJobRunResponse{Message: "hello"}, io)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(out.String(), "hello") {
+		t.Fatalf("live line not printed: %q", out.String())
+	}
+}
+
+func TestHandleLogMessage_DownloadURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("archived-line\n"))
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	io := iostreams.Test(nil, &out, &discardWriter{})
+	err := handleLogMessage(context.Background(),
+		&openv1alpha1service.LogJobRunResponse{LogDownloadUri: srv.URL}, io)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(out.String(), "archived-line") {
+		t.Fatalf("archived log not printed: %q", out.String())
+	}
+}
+
 func TestPrintArchivedLog_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("line-one\nline-two\n"))

--- a/pkg/cmd/action/logs_test.go
+++ b/pkg/cmd/action/logs_test.go
@@ -107,6 +107,22 @@ func TestPrintArchivedLog_Non200(t *testing.T) {
 	}
 }
 
+func TestPrintArchivedLog_NotFoundIsClean(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	io := iostreams.Test(nil, &out, &discardWriter{})
+	if err := printArchivedLog(context.Background(), srv.URL, io); err != nil {
+		t.Fatalf("404 should be handled cleanly, got err: %v", err)
+	}
+	if !strings.Contains(out.String(), "No logs available") {
+		t.Fatalf("expected 'No logs available' message, got %q", out.String())
+	}
+}
+
 func TestAwaitJobRunStart_FollowPollsUntilRunning(t *testing.T) {
 	cli := &fakeJobRunClient{
 		getQueue: []*openv1alpha1resource.JobRun{


### PR DESCRIPTION
## What

Makes `cocli action logs` work for **finished** job runs, not just running ones — transparently, with no new flag.

- **Running job:** stream live pod logs (unchanged).
- **Finished job (pod/workflow GC'd):** the server (apiary) returns a presigned URL for the archived log in `LogJobRunResponse.log_download_uri`; cocli downloads it and prints the contents.
- **Not-yet-started job (queued/scheduling):** no pod and no archive yet — with `-f`, poll and wait for it to start; without `-f`, report the state and exit cleanly (instead of appearing to "finish" with no output). _(addresses review feedback)_
- **Finished job with no archived log** (no output, or archival off when it ran): report `No logs available for this job run.` rather than a raw 404. _(found via e2e monkey testing)_

## Docs
Added a `Long` description + `Examples` to `cocli action logs -h` covering the live-vs-archived behavior and the `-j` / `--node` / `-f` flags.

## Tests
Extracted per-message handling into `handleLogMessage` and added unit tests: `handleLogMessage` (live line / archived download), `printArchivedLog` (success / 404 / 500), `awaitJobRunStart` (already-started / no-follow / poll-until-running / GetJobRun error / canceled), `jobRunNotStarted`. CI: build, codecov/project, ubuntu+macos tests all green.

## Dependencies
- coscene-openapi #69 (`log_download_uri`) — merged; go.mod bumped to that SDK snapshot.
- apiary #81 — emits the presigned URL (paired).
- integration-tests #6 — self-reproducing Argo log archival for the e2e env.

## Validated e2e
On the remote-dev-container e2e env: `cocli action logs <finished-run> -j 0` → apiary emitted a **publicly-accessible** presigned URL → cocli downloaded + printed the archived encoder log (exit 0). Edge cases + 5× concurrent exercised via a monkey test.