### PR TITLE
fix(action logs): exit non-zero on error

### DIFF
--- a/pkg/cmd/action/logs.go
+++ b/pkg/cmd/action/logs.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	openv1alpha1enums "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/enums"
@@ -420,6 +421,12 @@ func nextDelay(d time.Duration) time.Duration {
 	return next
 }
 
+// exitf prints an error message to stderr and terminates with a non-zero exit
+// code. The command uses cobra's Run (not RunE), so returning would exit 0 and
+// hide failures from scripts/CI; exiting here mirrors the sibling commands'
+// log.Fatalf behavior while preserving the iostreams-formatted message. Clean
+// Ctrl-C (context.Canceled) paths return before reaching exitf and still exit 0.
 func exitf(io *iostreams.IOStreams, format string, a ...interface{}) {
 	io.Eprintln(fmt.Sprintf(format, a...))
+	os.Exit(1)
 }


### PR DESCRIPTION
## Problem
`cocli action logs` uses cobra `Run` (not `RunE`) and reports errors via `exitf`, which only wrote to stderr and returned. Every error path therefore exited **0** — a failed `cocli action logs` (bad action-run id, project resolution failure, stream error, DAG-resolution failure) looked successful to scripts and CI.

## Fix
`exitf` now terminates with `os.Exit(1)`, mirroring the sibling commands' `log.Fatalf` behavior while preserving the iostreams-formatted message. Clean Ctrl-C (`context.Canceled`) paths return before `exitf` and still exit 0.

Chose this over converting to `RunE` because the root command sets no `SilenceUsage`/`SilenceErrors`, so `RunE` would dump full usage text on every error — a UX regression — and `Run`+immediate-exit is the established pattern across the action commands.

## Verification
`go build ./...` + `go vet ./pkg/cmd/action/...` pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coCLI/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784778756&installation_id=141984720&pr_number=180&repository=coscene-io%2FcoCLI&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoCLI%2Fpull%2F180&signature=28fbaad1da935935bcfd64e8b7f44411bfd871d38d9254ab124fbba1b9824045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->