### PR TITLE
fix(action logs): resolve job run node before streaming

### DIFF
--- a/pkg/cmd/action/logs.go
+++ b/pkg/cmd/action/logs.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"time"
 
 	openv1alpha1enums "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/enums"
@@ -120,13 +121,21 @@ of whether the run is in progress or already completed.
 				return
 			}
 
+			resolvedNode, err := resolveLogNode(cmd.Context(), cli, jobRunName, node)
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+				exitf(io, "%v", err)
+				return
+			}
 			streamFn := func(ctx context.Context, n string) error {
 				return streamOnce(ctx, cli, jobRunName, n, io)
 			}
 			dagFn := func(ctx context.Context) (string, error) {
 				return resolveDefaultNode(ctx, cli, jobRunName)
 			}
-			if err = followLogs(cmd.Context(), node, follow, io, streamFn, dagFn); err != nil {
+			if err = followLogs(cmd.Context(), resolvedNode, follow, io, streamFn, dagFn); err != nil {
 				if errors.Is(err, context.Canceled) {
 					return // clean Ctrl-C exit
 				}
@@ -311,6 +320,21 @@ func streamOnce(ctx context.Context, cli api.JobRunInterface, jobRunName, node s
 	return stream.Err()
 }
 
+func resolveLogNode(ctx context.Context, cli api.JobRunInterface, jobRunName, node string) (string, error) {
+	dag, err := cli.GetJobRunDag(ctx, jobRunName)
+	if err != nil {
+		return "", err
+	}
+	nodes := dag.GetNodes()
+	if node != "" {
+		if _, ok := nodes[node]; ok {
+			return node, nil
+		}
+		return "", fmt.Errorf("job run node %q not found. Available: %v", node, nodeNames(nodes))
+	}
+	return resolveDefaultNodeFromNodes(nodes)
+}
+
 // handleLogMessage renders one LogJobRun response: a live log line (message),
 // or — for a finished job run — a presigned URL (log_download_uri) whose
 // archived log is downloaded and printed.
@@ -365,17 +389,25 @@ func resolveDefaultNode(ctx context.Context, cli api.JobRunInterface, jobRunName
 	if err != nil {
 		return "", err
 	}
-	nodes := dag.GetNodes()
+	return resolveDefaultNodeFromNodes(dag.GetNodes())
+}
+
+func resolveDefaultNodeFromNodes(nodes map[string]*openv1alpha1resource.JobRunNode) (string, error) {
 	if len(nodes) == 1 {
 		for nodeName := range nodes {
 			return nodeName, nil
 		}
 	}
+	return "", fmt.Errorf("job run has multiple nodes; specify one with --node. Available: %v", nodeNames(nodes))
+}
+
+func nodeNames(nodes map[string]*openv1alpha1resource.JobRunNode) []string {
 	nodeNames := make([]string, 0, len(nodes))
 	for nodeName := range nodes {
 		nodeNames = append(nodeNames, nodeName)
 	}
-	return "", fmt.Errorf("job run has multiple nodes; specify one with --node. Available: %v", nodeNames)
+	sort.Strings(nodeNames)
+	return nodeNames
 }
 
 func isNodeNotFound(err error) bool {

--- a/pkg/cmd/action/logs_test.go
+++ b/pkg/cmd/action/logs_test.go
@@ -301,6 +301,39 @@ func TestFollowLogs_RetriableReconnectStopsOnCanceledBackoff(t *testing.T) {
 	}
 }
 
+func TestResolveLogNode(t *testing.T) {
+	t.Run("explicit node validates against dag", func(t *testing.T) {
+		cli := &fakeJobRunClient{dag: &openv1alpha1resource.JobRunDag{
+			Nodes: map[string]*openv1alpha1resource.JobRunNode{"echo": {Name: "echo"}},
+		}}
+		got, err := resolveLogNode(context.Background(), cli, "jr", "echo")
+		if err != nil || got != "echo" {
+			t.Fatalf("got %q, err %v", got, err)
+		}
+	})
+
+	t.Run("empty node resolves from dag", func(t *testing.T) {
+		cli := &fakeJobRunClient{dag: &openv1alpha1resource.JobRunDag{
+			Nodes: map[string]*openv1alpha1resource.JobRunNode{"echo": {Name: "echo"}},
+		}}
+		got, err := resolveLogNode(context.Background(), cli, "jr", "")
+		if err != nil || got != "echo" {
+			t.Fatalf("got %q, err %v", got, err)
+		}
+	})
+
+	t.Run("explicit unknown node errors before streaming", func(t *testing.T) {
+		cli := &fakeJobRunClient{dag: &openv1alpha1resource.JobRunDag{
+			Nodes: map[string]*openv1alpha1resource.JobRunNode{"echo": {Name: "echo"}},
+		}}
+		_, err := resolveLogNode(context.Background(), cli, "jr", "missing")
+		if err == nil || !strings.Contains(err.Error(), `job run node "missing" not found`) ||
+			!strings.Contains(err.Error(), "Available: [echo]") {
+			t.Fatalf("expected invalid node error with available nodes, got %v", err)
+		}
+	})
+}
+
 func TestResolveDefaultNode(t *testing.T) {
 	t.Run("single node auto-filled", func(t *testing.T) {
 		cli := &fakeJobRunClient{dag: &openv1alpha1resource.JobRunDag{


### PR DESCRIPTION
## Summary

`cocli action logs` now resolves the job run DAG before opening the log stream, so single-node runs no longer send an empty node to the backend and land on a missing archived log. Explicit `--node` values are also validated against the DAG first; an unknown node now fails immediately with the available node names instead of attempting to stream a non-existent node.

## Validation

- `go test ./pkg/cmd/action`
- `go test ./...`
- Rebuilt `/Users/juchao/go/bin/cocli`
- Ran a staging `sleep` action and followed the new run with `action logs -f`; logs streamed `1` through `15` and exited cleanly with the run in `SUCCEEDED`
- Verified `--node missing` returns `job run node "missing" not found. Available: [echo]`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coCLI/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785324580&installation_id=141984720&pr_number=181&repository=coscene-io%2FcoCLI&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoCLI%2Fpull%2F181&signature=f89d932eac506cf032e66573db43c201f047d1986bc3be346891e53c3218399b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->