### PR TITLE
feat(config): global --profile flag for per-invocation profile override

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,33 @@ Verify installation:
 cocli --version
 ```
 
+## Profiles
+
+`cocli` stores named login profiles in its config file and uses the configured
+`current-profile` by default (switch with `cocli login switch <name>`).
+
+To target a different profile for a single command without changing the config,
+use the global `--profile` flag:
+
+```bash
+cocli record list --profile staging
+```
+
+You can also drive a one-off profile entirely from environment variables by
+setting the complete `COS_*` set (`COS_ENDPOINT`, `COS_TOKEN`, `COS_PROJECT`;
+optional `COS_PROJECTID`). A partial set is ignored.
+
+Resolution precedence (highest first):
+
+```
+--profile NAME  >  complete COS_* env  >  config current-profile
+```
+
+`--profile` and `COS_*` overrides are applied in memory only and are never
+written back to the config file, so different profiles can be used concurrently.
+The `--profile` flag has no effect on `cocli login` subcommands, which always
+operate on the on-disk config.
+
 ## Help and Docs
 
 - Command help: `cocli <command> -h`

--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -1,0 +1,34 @@
+// Copyright 2024 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "context"
+
+type profileManagerCtxKey struct{}
+
+// ContextWithProfileManager returns a copy of ctx carrying the resolved profile
+// manager. The root PersistentPreRun stashes the manager it resolves so that
+// downstream commands reuse it instead of resolving (and re-authenticating) again.
+func ContextWithProfileManager(ctx context.Context, pm *ProfileManager) context.Context {
+	return context.WithValue(ctx, profileManagerCtxKey{}, pm)
+}
+
+// ProfileManagerFromContext returns the profile manager stashed by the root
+// PersistentPreRun, if any. The bool is false for commands that skip the root
+// auth check (e.g. login/registry), which resolve their own manager.
+func ProfileManagerFromContext(ctx context.Context) (*ProfileManager, bool) {
+	pm, ok := ctx.Value(profileManagerCtxKey{}).(*ProfileManager)
+	return pm, ok
+}

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -110,6 +110,9 @@ func (p *Profile) Validate() error {
 
 // CheckAuth checks if the profile has the org and project name set.
 func (p *Profile) CheckAuth() bool {
+	if p == nil {
+		return false
+	}
 	return p.Org != "" && p.ProjectName != ""
 }
 

--- a/internal/config/provide.go
+++ b/internal/config/provide.go
@@ -45,13 +45,19 @@ func Provide(path string) Provider {
 	return &globalConfig{path: path}
 }
 
-// GetProfileManager loads the profile manager from the config file
-// Note that loading from config have higher priority and that loading from env have the following format:
-// COS_ENDPOINT,
-// COS_TOKEN,
-// COS_PROJECT
-// Note that loading profile from env will change the config file
-// Also if COS_PROJECTID is set in the
+// EnvProfileName is the synthetic profile name assigned to a profile that is
+// built entirely from COS_* environment variables (env-inject). It never
+// appears in the on-disk config and is never persisted.
+const EnvProfileName = "ENV_LOADED_PROFILE"
+
+// GetProfileManager loads the profile manager from the config file only.
+//
+// Env-inject (building a profile from COS_ENDPOINT / COS_TOKEN / COS_PROJECT)
+// and the --profile override are handled by ResolveProfileManager, which wraps
+// this method. Callers that need override/env precedence (all data-plane
+// commands and the root auth check) must go through ResolveProfileManager.
+// Config-plane commands (login *) call this directly so they always operate on
+// the real on-disk config.
 func (cfg *globalConfig) GetProfileManager() (*ProfileManager, error) {
 	if err := cfg.loadYaml("current-profile", &cfg.CurrentProfile); err != nil {
 		return nil, errors.Wrapf(err, "unable to load current-profile from %s", cfg.path)
@@ -66,32 +72,48 @@ func (cfg *globalConfig) GetProfileManager() (*ProfileManager, error) {
 
 	if err := pm.Validate(); err != nil {
 		return nil, errors.Wrapf(err, "profile validation failed")
-	} else if !pm.IsEmpty() {
-		return pm, nil
-	}
-
-	// Config profile empty, loading from env
-	envLoadedProfile := &Profile{Name: "ENV_LOADED_PROFILE"}
-	if err := cfg.loadEnv("", envLoadedProfile); err != nil {
-		return nil, errors.Wrapf(err, "unable to load profile from env")
-	}
-	// Hack to prioritize filling project name with project id
-	if projectID := os.Getenv("COS_PROJECTID"); projectID != "" {
-		envLoadedProfile.ProjectName = name.Project{ProjectID: projectID}.String()
-	}
-
-	if envLoadedProfile.EndPoint == "" || envLoadedProfile.Token == "" || envLoadedProfile.ProjectSlug == "" {
-		return pm, nil
-	}
-	pm = new(ProfileManager)
-	pm.CurrentProfile = envLoadedProfile.Name
-	pm.Profiles = []*Profile{envLoadedProfile}
-
-	if err := pm.Validate(); err != nil {
-		return nil, errors.Wrapf(err, "profile validation failed")
 	}
 
 	return pm, nil
+}
+
+// buildEnvProfileFromOS builds a profile from the COS_* environment variables.
+// It returns (nil, nil) when the env set is incomplete — i.e. any of endpoint,
+// token, or project slug is missing — so partial COS_* is silently ignored.
+// The COS_PROJECTID hack fills the project name directly when present.
+func buildEnvProfileFromOS() (*Profile, error) {
+	k := koanf.New(".")
+	if err := k.Load(
+		env.Provider(
+			"COS",
+			"_",
+			func(s string) string {
+				return strings.ToLower(strings.TrimPrefix(s, "COS_"))
+			},
+		),
+		nil,
+	); err != nil {
+		return nil, errors.Wrap(err, "load config from env")
+	}
+
+	p := &Profile{}
+	if err := k.Unmarshal("", p); err != nil {
+		return nil, errors.Wrap(err, "unmarshal env")
+	}
+	// Force the synthetic name after unmarshal so a stray COS_NAME cannot
+	// rename (and thereby alias) the env-inject profile.
+	p.Name = EnvProfileName
+
+	// Hack to prioritize filling project name with project id
+	if projectID := os.Getenv("COS_PROJECTID"); projectID != "" {
+		p.ProjectName = name.Project{ProjectID: projectID}.String()
+	}
+
+	if p.EndPoint == "" || p.Token == "" || p.ProjectSlug == "" {
+		return nil, nil
+	}
+
+	return p, nil
 }
 
 // Persist saves the profile manager to the config file
@@ -146,28 +168,6 @@ func (cfg *globalConfig) persist() error {
 	err = os.WriteFile(originalConfig.path, yamlStr, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "unable to write yaml to %s", originalConfig.path)
-	}
-	return nil
-}
-
-// loadEnv loads the config from environment variables
-func (cfg *globalConfig) loadEnv(path string, any interface{}) error {
-	k := koanf.New(".")
-	if err := k.Load(
-		env.Provider(
-			"COS",
-			"_",
-			func(s string) string {
-				return strings.ToLower(strings.TrimPrefix(s, "COS_"))
-			},
-		),
-		nil,
-	); err != nil {
-		return errors.Wrapf(err, "load config from env")
-	}
-
-	if err := k.Unmarshal(path, any); err != nil {
-		return errors.Wrap(err, "unmarshal env")
 	}
 	return nil
 }

--- a/internal/config/provide_test.go
+++ b/internal/config/provide_test.go
@@ -1,0 +1,88 @@
+// Copyright 2024 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleConfig = `current-profile: p1
+profiles:
+  - name: p1
+    endpoint: https://openapi.a.coscene.cn
+    token: t1
+    project: s1
+    org: o1
+    project-name: projects/1
+  - name: p2
+    endpoint: https://openapi.b.coscene.cn
+    token: t2
+    project: s2
+    org: o2
+    project-name: projects/2
+`
+
+func writeTempConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+	return path
+}
+
+func TestProvide_GetProfileManager_LoadsConfig(t *testing.T) {
+	clearCosEnv(t)
+	path := writeTempConfig(t, sampleConfig)
+
+	pm, err := Provide(path).GetProfileManager()
+	require.NoError(t, err)
+	require.NotNil(t, pm)
+	assert.Equal(t, "p1", pm.CurrentProfile)
+	assert.Len(t, pm.Profiles, 2)
+	assert.Equal(t, "t1", pm.GetCurrentProfile().Token)
+}
+
+func TestProvide_GetProfileManager_EmptyConfig(t *testing.T) {
+	clearCosEnv(t)
+	path := writeTempConfig(t, "")
+
+	pm, err := Provide(path).GetProfileManager()
+	require.NoError(t, err)
+	require.NotNil(t, pm)
+	assert.True(t, pm.IsEmpty())
+}
+
+func TestProvide_Persist_RoundTrip(t *testing.T) {
+	clearCosEnv(t)
+	path := writeTempConfig(t, sampleConfig)
+	cfg := Provide(path)
+
+	pm, err := cfg.GetProfileManager()
+	require.NoError(t, err)
+
+	// Switch current-profile and persist.
+	pm.CurrentProfile = "p2"
+	require.NoError(t, cfg.Persist(pm))
+
+	// Reload from disk through a fresh provider and confirm the change stuck.
+	reloaded, err := Provide(path).GetProfileManager()
+	require.NoError(t, err)
+	assert.Equal(t, "p2", reloaded.CurrentProfile)
+	assert.Len(t, reloaded.Profiles, 2)
+}

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -1,0 +1,119 @@
+// Copyright 2024 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// ResolveProfileManager resolves the active profile manager applying the global
+// --profile override and COS_* env-inject on top of the on-disk config.
+//
+// Precedence, highest first:
+//
+//		--profile NAME  >  complete COS_* env profile  >  config current-profile
+//
+//	  - override set: select the named profile from config; hard error if absent.
+//	    If a complete env profile is also present, it is ignored with a warning.
+//	  - else complete COS_* env: build an ephemeral profile from the env; if the
+//	    config is non-empty, warn that the env profile overrides the configured
+//	    current-profile.
+//	  - else: use the config current-profile.
+//
+// The returned ephemeral bool is true whenever resolution was driven by the
+// override or the env profile. When ephemeral, the result MUST NOT be persisted
+// (doing so would let concurrent invocations clobber the shared config file),
+// and the overridden profile is authenticated in memory before returning so
+// downstream commands see a populated Org / ProjectName.
+func ResolveProfileManager(ctx context.Context, p Provider, override string) (pm *ProfileManager, ephemeral bool, err error) {
+	pm, err = p.GetProfileManager()
+	if err != nil {
+		return nil, false, err
+	}
+
+	envProfile, err := buildEnvProfileFromOS()
+	if err != nil {
+		return nil, false, err
+	}
+
+	// 1. --profile NAME wins.
+	if override != "" {
+		if pm == nil || !pm.hasProfile(override) {
+			return nil, false, errors.Errorf("profile %q not found in config", override)
+		}
+		pm.CurrentProfile = override
+		if envProfile != nil {
+			log.Warnf("COS_* env profile ignored; --profile %q takes precedence", override)
+		}
+		if err = ephemeralAuth(ctx, pm); err != nil {
+			return nil, false, err
+		}
+		return pm, true, nil
+	}
+
+	// 2. Complete COS_* env profile.
+	if envProfile != nil {
+		// Validate the env-built profile (endpoint format etc.) so a malformed
+		// COS_ENDPOINT fails with a clear message rather than surfacing later
+		// as a confusing network error — matching pre-refactor behavior.
+		if err = envProfile.Validate(); err != nil {
+			return nil, false, errors.Wrap(err, "invalid COS_* env profile")
+		}
+		if pm != nil && !pm.IsEmpty() {
+			log.Warnf("COS_* env profile overrides configured current-profile %q", pm.CurrentProfile)
+		}
+		envPM := &ProfileManager{
+			CurrentProfile: envProfile.Name,
+			Profiles:       []*Profile{envProfile},
+		}
+		if err = ephemeralAuth(ctx, envPM); err != nil {
+			return nil, false, err
+		}
+		return envPM, true, nil
+	}
+
+	// 3. Config current-profile (persist allowed).
+	return pm, false, nil
+}
+
+// ephemeralAuth is the in-memory authentication step for resolved profiles.
+// It is a package variable so tests can stub out the network call.
+var ephemeralAuth = authEphemeral
+
+// authEphemeral authenticates the current profile in memory when it is not
+// already authenticated, so an overridden / env-inject profile has its Org and
+// ProjectName populated without touching disk.
+func authEphemeral(ctx context.Context, pm *ProfileManager) error {
+	if pm.CheckAuth() {
+		return nil
+	}
+	if err := pm.Auth(ctx); err != nil {
+		return errors.Wrap(err, "unable to authenticate resolved profile")
+	}
+	return nil
+}
+
+// hasProfile reports whether a profile with the given name exists.
+func (pm *ProfileManager) hasProfile(name string) bool {
+	for _, p := range pm.Profiles {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// assertAnErr is a sentinel error for stubbed auth-failure tests.
-var assertAnErr = errors.New("stub auth failure")
+// errStubAuth is a sentinel error for stubbed auth-failure tests.
+var errStubAuth = errors.New("stub auth failure")
 
 // fakeProvider returns a fixed ProfileManager, implementing Provider.
 type fakeProvider struct {
@@ -206,7 +206,7 @@ func TestResolveProfileManager_EphemeralAuthError_Override(t *testing.T) {
 	clearCosEnv(t)
 	orig := ephemeralAuth
 	ephemeralAuth = func(_ context.Context, _ *ProfileManager) error {
-		return assertAnErr
+		return errStubAuth
 	}
 	t.Cleanup(func() { ephemeralAuth = orig })
 
@@ -223,7 +223,7 @@ func TestResolveProfileManager_EphemeralAuthError_Env(t *testing.T) {
 	t.Setenv("COS_PROJECT", "env-slug")
 	orig := ephemeralAuth
 	ephemeralAuth = func(_ context.Context, _ *ProfileManager) error {
-		return assertAnErr
+		return errStubAuth
 	}
 	t.Cleanup(func() { ephemeralAuth = orig })
 

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -1,0 +1,224 @@
+// Copyright 2024 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeProvider returns a fixed ProfileManager, implementing Provider.
+type fakeProvider struct {
+	pm *ProfileManager
+}
+
+func (f *fakeProvider) GetProfileManager() (*ProfileManager, error) { return f.pm, nil }
+func (f *fakeProvider) Persist(_ *ProfileManager) error             { return nil }
+
+// stubAuth replaces the network auth step for the duration of a test.
+func stubAuth(t *testing.T) {
+	t.Helper()
+	orig := ephemeralAuth
+	ephemeralAuth = func(_ context.Context, _ *ProfileManager) error { return nil }
+	t.Cleanup(func() { ephemeralAuth = orig })
+}
+
+func twoProfilePM() *ProfileManager {
+	return &ProfileManager{
+		CurrentProfile: "p1",
+		Profiles: []*Profile{
+			{Name: "p1", EndPoint: "https://openapi.a.coscene.cn", Token: "t1", ProjectSlug: "s1", Org: "o1", ProjectName: "projects/1"},
+			{Name: "p2", EndPoint: "https://openapi.b.coscene.cn", Token: "t2", ProjectSlug: "s2", Org: "o2", ProjectName: "projects/2"},
+		},
+	}
+}
+
+func clearCosEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{"COS_ENDPOINT", "COS_TOKEN", "COS_PROJECT", "COS_PROJECTID", "COS_ORG"} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestResolveProfileManager_NoOverrideNoEnv_UsesConfig(t *testing.T) {
+	stubAuth(t)
+	clearCosEnv(t)
+
+	pm, ephemeral, err := ResolveProfileManager(context.Background(), &fakeProvider{pm: twoProfilePM()}, "")
+	require.NoError(t, err)
+	assert.False(t, ephemeral, "config path must be persistable")
+	assert.Equal(t, "p1", pm.CurrentProfile)
+}
+
+func TestResolveProfileManager_OverrideSelectsNamed(t *testing.T) {
+	stubAuth(t)
+	clearCosEnv(t)
+
+	pm, ephemeral, err := ResolveProfileManager(context.Background(), &fakeProvider{pm: twoProfilePM()}, "p2")
+	require.NoError(t, err)
+	assert.True(t, ephemeral, "override must be ephemeral (no persist)")
+	assert.Equal(t, "p2", pm.CurrentProfile)
+}
+
+func TestResolveProfileManager_OverrideNotFound_Errors(t *testing.T) {
+	stubAuth(t)
+	clearCosEnv(t)
+
+	_, _, err := ResolveProfileManager(context.Background(), &fakeProvider{pm: twoProfilePM()}, "nope")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestResolveProfileManager_CompleteEnv_OverridesConfig(t *testing.T) {
+	stubAuth(t)
+	clearCosEnv(t)
+	t.Setenv("COS_ENDPOINT", "https://openapi.env.coscene.cn")
+	t.Setenv("COS_TOKEN", "env-token")
+	t.Setenv("COS_PROJECT", "env-slug")
+
+	pm, ephemeral, err := ResolveProfileManager(context.Background(), &fakeProvider{pm: twoProfilePM()}, "")
+	require.NoError(t, err)
+	assert.True(t, ephemeral)
+	assert.Equal(t, EnvProfileName, pm.CurrentProfile)
+	assert.Equal(t, "env-token", pm.GetCurrentProfile().Token)
+}
+
+func TestResolveProfileManager_FlagBeatsEnv(t *testing.T) {
+	stubAuth(t)
+	clearCosEnv(t)
+	t.Setenv("COS_ENDPOINT", "https://openapi.env.coscene.cn")
+	t.Setenv("COS_TOKEN", "env-token")
+	t.Setenv("COS_PROJECT", "env-slug")
+
+	pm, ephemeral, err := ResolveProfileManager(context.Background(), &fakeProvider{pm: twoProfilePM()}, "p2")
+	require.NoError(t, err)
+	assert.True(t, ephemeral)
+	assert.Equal(t, "p2", pm.CurrentProfile, "--profile must win over complete COS_* env")
+}
+
+func TestResolveProfileManager_PartialEnv_Ignored(t *testing.T) {
+	stubAuth(t)
+	clearCosEnv(t)
+	t.Setenv("COS_TOKEN", "only-token") // endpoint + project missing
+
+	pm, ephemeral, err := ResolveProfileManager(context.Background(), &fakeProvider{pm: twoProfilePM()}, "")
+	require.NoError(t, err)
+	assert.False(t, ephemeral, "partial env must fall through to config")
+	assert.Equal(t, "p1", pm.CurrentProfile)
+}
+
+func TestResolveProfileManager_CompleteEnv_EmptyConfig(t *testing.T) {
+	stubAuth(t)
+	clearCosEnv(t)
+	t.Setenv("COS_ENDPOINT", "https://openapi.env.coscene.cn")
+	t.Setenv("COS_TOKEN", "env-token")
+	t.Setenv("COS_PROJECT", "env-slug")
+
+	pm, ephemeral, err := ResolveProfileManager(context.Background(), &fakeProvider{pm: &ProfileManager{}}, "")
+	require.NoError(t, err)
+	assert.True(t, ephemeral)
+	assert.Equal(t, EnvProfileName, pm.CurrentProfile)
+}
+
+func TestResolveProfileManager_Override_EmptyConfig_Errors(t *testing.T) {
+	stubAuth(t)
+	clearCosEnv(t)
+
+	_, _, err := ResolveProfileManager(context.Background(), &fakeProvider{pm: &ProfileManager{}}, "p1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestResolveProfileManager_MalformedEnvEndpoint_Errors(t *testing.T) {
+	stubAuth(t)
+	clearCosEnv(t)
+	t.Setenv("COS_ENDPOINT", "http://not-openapi.example.com")
+	t.Setenv("COS_TOKEN", "env-token")
+	t.Setenv("COS_PROJECT", "env-slug")
+
+	_, _, err := ResolveProfileManager(context.Background(), &fakeProvider{pm: twoProfilePM()}, "")
+	require.Error(t, err, "malformed COS_ENDPOINT must be rejected, not silently accepted")
+	assert.Contains(t, err.Error(), "env profile")
+}
+
+func TestResolveProfileManager_FlagSelectsConfigProfile_NotEnvTainted(t *testing.T) {
+	stubAuth(t)
+	clearCosEnv(t)
+	t.Setenv("COS_ENDPOINT", "https://openapi.env.coscene.cn")
+	t.Setenv("COS_TOKEN", "env-token")
+	t.Setenv("COS_PROJECT", "env-slug")
+
+	pm, _, err := ResolveProfileManager(context.Background(), &fakeProvider{pm: twoProfilePM()}, "p2")
+	require.NoError(t, err)
+	assert.Equal(t, "t2", pm.GetCurrentProfile().Token, "must select config p2, not the env profile")
+}
+
+func TestBuildEnvProfileFromOS_IgnoresCosName(t *testing.T) {
+	clearCosEnv(t)
+	t.Setenv("COS_ENDPOINT", "https://openapi.env.coscene.cn")
+	t.Setenv("COS_TOKEN", "tok")
+	t.Setenv("COS_PROJECT", "slug")
+	t.Setenv("COS_NAME", "attacker-alias")
+
+	p, err := buildEnvProfileFromOS()
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, EnvProfileName, p.Name, "COS_NAME must not rename the env sentinel profile")
+}
+
+func TestProfileCheckAuth_NilSafe(t *testing.T) {
+	var p *Profile
+	assert.False(t, p.CheckAuth(), "CheckAuth on nil profile must not panic")
+}
+
+func TestBuildEnvProfileFromOS(t *testing.T) {
+	t.Run("complete", func(t *testing.T) {
+		clearCosEnv(t)
+		t.Setenv("COS_ENDPOINT", "https://openapi.env.coscene.cn")
+		t.Setenv("COS_TOKEN", "tok")
+		t.Setenv("COS_PROJECT", "slug")
+
+		p, err := buildEnvProfileFromOS()
+		require.NoError(t, err)
+		require.NotNil(t, p)
+		assert.Equal(t, EnvProfileName, p.Name)
+		assert.Equal(t, "slug", p.ProjectSlug)
+	})
+
+	t.Run("partial returns nil", func(t *testing.T) {
+		clearCosEnv(t)
+		t.Setenv("COS_TOKEN", "tok")
+
+		p, err := buildEnvProfileFromOS()
+		require.NoError(t, err)
+		assert.Nil(t, p)
+	})
+
+	t.Run("projectid hack fills project name", func(t *testing.T) {
+		clearCosEnv(t)
+		t.Setenv("COS_ENDPOINT", "https://openapi.env.coscene.cn")
+		t.Setenv("COS_TOKEN", "tok")
+		t.Setenv("COS_PROJECT", "slug")
+		t.Setenv("COS_PROJECTID", "abc123")
+
+		p, err := buildEnvProfileFromOS()
+		require.NoError(t, err)
+		require.NotNil(t, p)
+		assert.Contains(t, p.ProjectName, "abc123")
+	})
+}

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -16,11 +16,15 @@ package config
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// assertAnErr is a sentinel error for stubbed auth-failure tests.
+var assertAnErr = errors.New("stub auth failure")
 
 // fakeProvider returns a fixed ProfileManager, implementing Provider.
 type fakeProvider struct {
@@ -184,6 +188,49 @@ func TestBuildEnvProfileFromOS_IgnoresCosName(t *testing.T) {
 func TestProfileCheckAuth_NilSafe(t *testing.T) {
 	var p *Profile
 	assert.False(t, p.CheckAuth(), "CheckAuth on nil profile must not panic")
+}
+
+func TestAuthEphemeral_AlreadyAuthed_NoNetwork(t *testing.T) {
+	// A profile already carrying Org + ProjectName passes CheckAuth, so
+	// authEphemeral must short-circuit and return nil without any network call.
+	pm := &ProfileManager{
+		CurrentProfile: "p1",
+		Profiles: []*Profile{
+			{Name: "p1", EndPoint: "https://openapi.a.coscene.cn", Token: "t1", ProjectSlug: "s1", Org: "o1", ProjectName: "projects/1"},
+		},
+	}
+	require.NoError(t, authEphemeral(context.Background(), pm))
+}
+
+func TestResolveProfileManager_EphemeralAuthError_Override(t *testing.T) {
+	clearCosEnv(t)
+	orig := ephemeralAuth
+	ephemeralAuth = func(_ context.Context, _ *ProfileManager) error {
+		return assertAnErr
+	}
+	t.Cleanup(func() { ephemeralAuth = orig })
+
+	pm, ephemeral, err := ResolveProfileManager(context.Background(), &fakeProvider{pm: twoProfilePM()}, "p2")
+	require.Error(t, err, "auth failure on override path must propagate")
+	assert.Nil(t, pm)
+	assert.False(t, ephemeral)
+}
+
+func TestResolveProfileManager_EphemeralAuthError_Env(t *testing.T) {
+	clearCosEnv(t)
+	t.Setenv("COS_ENDPOINT", "https://openapi.env.coscene.cn")
+	t.Setenv("COS_TOKEN", "env-token")
+	t.Setenv("COS_PROJECT", "env-slug")
+	orig := ephemeralAuth
+	ephemeralAuth = func(_ context.Context, _ *ProfileManager) error {
+		return assertAnErr
+	}
+	t.Cleanup(func() { ephemeralAuth = orig })
+
+	pm, ephemeral, err := ResolveProfileManager(context.Background(), &fakeProvider{pm: twoProfilePM()}, "")
+	require.Error(t, err, "auth failure on env path must propagate")
+	assert.Nil(t, pm)
+	assert.False(t, ephemeral)
 }
 
 func TestBuildEnvProfileFromOS(t *testing.T) {

--- a/pkg/cmd/action/list.go
+++ b/pkg/cmd/action/list.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coscene-io/cocli/internal/printer"
 	"github.com/coscene-io/cocli/internal/printer/printable"
 	"github.com/coscene-io/cocli/internal/printer/table"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	mapset "github.com/deckarep/golang-set/v2"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -44,11 +45,7 @@ func NewListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 		Args:                  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/action/list.go
+++ b/pkg/cmd/action/list.go
@@ -44,7 +44,11 @@ func NewListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 		Args:                  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/action/list_run.go
+++ b/pkg/cmd/action/list_run.go
@@ -27,6 +27,7 @@ import (
 	"github.com/coscene-io/cocli/internal/printer/printable"
 	"github.com/coscene-io/cocli/internal/printer/table"
 	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	mapset "github.com/deckarep/golang-set/v2"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -47,11 +48,7 @@ func NewListRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fun
 		Args:                  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/action/list_run.go
+++ b/pkg/cmd/action/list_run.go
@@ -47,7 +47,11 @@ func NewListRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fun
 		Args:                  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/action/logs.go
+++ b/pkg/cmd/action/logs.go
@@ -80,7 +80,12 @@ of whether the run is in progress or already completed.
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				exitf(io, "unable to resolve profile: %v", err)
+				return
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				exitf(io, "unable to get project name: %v", err)

--- a/pkg/cmd/action/logs.go
+++ b/pkg/cmd/action/logs.go
@@ -32,6 +32,7 @@ import (
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/name"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	"github.com/spf13/cobra"
 )
 
@@ -80,12 +81,7 @@ of whether the run is in progress or already completed.
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				exitf(io, "unable to resolve profile: %v", err)
-				return
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				exitf(io, "unable to get project name: %v", err)

--- a/pkg/cmd/action/run.go
+++ b/pkg/cmd/action/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/prompts"
 	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -40,11 +41,7 @@ func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/action/run.go
+++ b/pkg/cmd/action/run.go
@@ -40,7 +40,11 @@ func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/project/create.go
+++ b/pkg/cmd/project/create.go
@@ -30,6 +30,7 @@ import (
 	"github.com/coscene-io/cocli/internal/printer/printable"
 	"github.com/coscene-io/cocli/internal/printer/table"
 	"github.com/coscene-io/cocli/internal/prompts"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -54,17 +55,16 @@ func NewCreateCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 
 			if projectSlug == "" {
 				log.Fatalf("project name cannot be empty")
 			}
 
-			var projectRes *openv1alpha1resource.Project
+			var (
+				projectRes *openv1alpha1resource.Project
+				err        error
+			)
 
 			// Visibility is required
 			if visibility != "private" && visibility != "internal" {

--- a/pkg/cmd/project/create.go
+++ b/pkg/cmd/project/create.go
@@ -54,16 +54,17 @@ func NewCreateCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 
 			if projectSlug == "" {
 				log.Fatalf("project name cannot be empty")
 			}
 
-			var (
-				projectRes *openv1alpha1resource.Project
-				err        error
-			)
+			var projectRes *openv1alpha1resource.Project
 
 			// Visibility is required
 			if visibility != "private" && visibility != "internal" {

--- a/pkg/cmd/project/file.go
+++ b/pkg/cmd/project/file.go
@@ -75,7 +75,15 @@ func NewFileListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fu
 				log.Fatalf("--page must be >= 1")
 			}
 
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+
+			if err != nil {
+
+				log.Fatalf("Failed to resolve profile: %v", err)
+
+			}
 
 			projectName, err := pm.ProjectName(cmd.Context(), args[0])
 			if err != nil {
@@ -195,7 +203,11 @@ func NewFileDownloadCommand(cfgPath *string, io *iostreams.IOStreams, getProvide
 		Args:                  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 
 			// Handle args and flags.
 			projectName, err := pm.ProjectName(cmd.Context(), args[0])
@@ -355,7 +367,11 @@ func NewFileUploadCommand(cfgPath *string, io *iostreams.IOStreams, getProvider 
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 
 			projectName, err := pm.ProjectName(cmd.Context(), args[0])
 			if err != nil {
@@ -425,7 +441,11 @@ func NewFileDeleteCommand(cfgPath *string, io *iostreams.IOStreams, getProvider 
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.RangeArgs(1, 2),
 		Run: func(cmd *cobra.Command, args []string) {
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 
 			projectName, err := pm.ProjectName(cmd.Context(), args[0])
 			if err != nil {

--- a/pkg/cmd/project/file.go
+++ b/pkg/cmd/project/file.go
@@ -75,15 +75,7 @@ func NewFileListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fu
 				log.Fatalf("--page must be >= 1")
 			}
 
-			profileOverride, _ := cmd.Flags().GetString("profile")
-
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-
-			if err != nil {
-
-				log.Fatalf("Failed to resolve profile: %v", err)
-
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 
 			projectName, err := pm.ProjectName(cmd.Context(), args[0])
 			if err != nil {
@@ -203,11 +195,7 @@ func NewFileDownloadCommand(cfgPath *string, io *iostreams.IOStreams, getProvide
 		Args:                  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 
 			// Handle args and flags.
 			projectName, err := pm.ProjectName(cmd.Context(), args[0])
@@ -367,11 +355,7 @@ func NewFileUploadCommand(cfgPath *string, io *iostreams.IOStreams, getProvider 
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 
 			projectName, err := pm.ProjectName(cmd.Context(), args[0])
 			if err != nil {
@@ -441,11 +425,7 @@ func NewFileDeleteCommand(cfgPath *string, io *iostreams.IOStreams, getProvider 
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.RangeArgs(1, 2),
 		Run: func(cmd *cobra.Command, args []string) {
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 
 			projectName, err := pm.ProjectName(cmd.Context(), args[0])
 			if err != nil {

--- a/pkg/cmd/project/list.go
+++ b/pkg/cmd/project/list.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/printer"
 	"github.com/coscene-io/cocli/internal/printer/printable"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -53,15 +54,7 @@ func NewListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 				log.Fatalf("--page must be >= 1")
 			}
 
-			profileOverride, _ := cmd.Flags().GetString("profile")
-
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-
-			if err != nil {
-
-				log.Fatalf("Failed to resolve profile: %v", err)
-
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 
 			opts := &api.ListProjectsOptions{
 				DisplayNames:   keywords,
@@ -69,6 +62,7 @@ func NewListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 			}
 
 			var projects []*openv1alpha1resource.Project
+			var err error
 
 			if all {
 				projects, err = pm.ProjectCli().ListAllUserProjects(context.Background(), opts)

--- a/pkg/cmd/project/list.go
+++ b/pkg/cmd/project/list.go
@@ -53,7 +53,15 @@ func NewListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 				log.Fatalf("--page must be >= 1")
 			}
 
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+
+			if err != nil {
+
+				log.Fatalf("Failed to resolve profile: %v", err)
+
+			}
 
 			opts := &api.ListProjectsOptions{
 				DisplayNames:   keywords,
@@ -61,7 +69,6 @@ func NewListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 			}
 
 			var projects []*openv1alpha1resource.Project
-			var err error
 
 			if all {
 				projects, err = pm.ProjectCli().ListAllUserProjects(context.Background(), opts)

--- a/pkg/cmd/record/copy.go
+++ b/pkg/cmd/record/copy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/coscene-io/cocli/internal/name"
 	"github.com/coscene-io/cocli/internal/prompts"
 	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -39,11 +40,7 @@ func NewCopyCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 		Args:                  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 
 			// Get working project.
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)

--- a/pkg/cmd/record/copy.go
+++ b/pkg/cmd/record/copy.go
@@ -39,7 +39,11 @@ func NewCopyCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 		Args:                  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 
 			// Get working project.
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)

--- a/pkg/cmd/record/create.go
+++ b/pkg/cmd/record/create.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coscene-io/cocli/internal/customfield"
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/name"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	"github.com/coscene-io/cocli/pkg/cmd_utils/upload_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -48,11 +49,7 @@ func NewCreateCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func
 		Args:                  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/create.go
+++ b/pkg/cmd/record/create.go
@@ -48,7 +48,11 @@ func NewCreateCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func
 		Args:                  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/delete.go
+++ b/pkg/cmd/record/delete.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/prompts"
 	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -37,11 +38,7 @@ func NewDeleteCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func
 		Args:                  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/delete.go
+++ b/pkg/cmd/record/delete.go
@@ -37,7 +37,11 @@ func NewDeleteCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func
 		Args:                  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/describe.go
+++ b/pkg/cmd/record/describe.go
@@ -43,7 +43,11 @@ func NewDescribeCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fu
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/describe.go
+++ b/pkg/cmd/record/describe.go
@@ -26,6 +26,7 @@ import (
 	"github.com/coscene-io/cocli/internal/printer/printable"
 	"github.com/coscene-io/cocli/internal/printer/table"
 	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -43,11 +44,7 @@ func NewDescribeCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fu
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/download.go
+++ b/pkg/cmd/record/download.go
@@ -47,7 +47,11 @@ func NewDownloadCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fu
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/download.go
+++ b/pkg/cmd/record/download.go
@@ -47,11 +47,7 @@ func NewDownloadCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fu
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/file.go
+++ b/pkg/cmd/record/file.go
@@ -80,11 +80,7 @@ func NewFileListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fu
 			}
 
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)
@@ -215,11 +211,7 @@ func NewFileDownloadCommand(cfgPath *string, io *iostreams.IOStreams, getProvide
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)
@@ -385,11 +377,7 @@ func NewFileDeleteCommand(cfgPath *string, io *iostreams.IOStreams, getProvider 
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.RangeArgs(1, 2),
 		Run: func(cmd *cobra.Command, args []string) {
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)
@@ -473,11 +461,7 @@ func NewFileCopyCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fu
 		Args:                  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 
 			// Get working project.
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
@@ -583,11 +567,7 @@ func NewFileMoveCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fu
 		Args:                  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 
 			// Get working project.
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)

--- a/pkg/cmd/record/file.go
+++ b/pkg/cmd/record/file.go
@@ -80,7 +80,11 @@ func NewFileListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fu
 			}
 
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)
@@ -211,7 +215,11 @@ func NewFileDownloadCommand(cfgPath *string, io *iostreams.IOStreams, getProvide
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)
@@ -377,7 +385,11 @@ func NewFileDeleteCommand(cfgPath *string, io *iostreams.IOStreams, getProvider 
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.RangeArgs(1, 2),
 		Run: func(cmd *cobra.Command, args []string) {
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)
@@ -461,7 +473,11 @@ func NewFileCopyCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fu
 		Args:                  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 
 			// Get working project.
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
@@ -567,7 +583,11 @@ func NewFileMoveCommand(cfgPath *string, io *iostreams.IOStreams, getProvider fu
 		Args:                  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 
 			// Get working project.
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)

--- a/pkg/cmd/record/list.go
+++ b/pkg/cmd/record/list.go
@@ -26,6 +26,7 @@ import (
 	"github.com/coscene-io/cocli/internal/name"
 	"github.com/coscene-io/cocli/internal/printer"
 	"github.com/coscene-io/cocli/internal/printer/printable"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -57,11 +58,7 @@ func NewListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 			}
 
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/list.go
+++ b/pkg/cmd/record/list.go
@@ -57,7 +57,11 @@ func NewListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 			}
 
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/moment.go
+++ b/pkg/cmd/record/moment.go
@@ -73,11 +73,7 @@ func NewMomentCreateCommand(cfgPath *string, io *iostreams.IOStreams, getProvide
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)
@@ -239,11 +235,7 @@ func NewMomentListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider 
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)
@@ -295,11 +287,7 @@ func NewMomentDownloadCommand(cfgPath *string, io *iostreams.IOStreams, getProvi
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/moment.go
+++ b/pkg/cmd/record/moment.go
@@ -73,7 +73,11 @@ func NewMomentCreateCommand(cfgPath *string, io *iostreams.IOStreams, getProvide
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)
@@ -235,7 +239,11 @@ func NewMomentListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider 
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)
@@ -287,7 +295,11 @@ func NewMomentDownloadCommand(cfgPath *string, io *iostreams.IOStreams, getProvi
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/move.go
+++ b/pkg/cmd/record/move.go
@@ -39,7 +39,11 @@ func NewMoveCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 		Args:                  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 
 			// Get working project.
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)

--- a/pkg/cmd/record/move.go
+++ b/pkg/cmd/record/move.go
@@ -21,6 +21,7 @@ import (
 	"github.com/coscene-io/cocli/internal/name"
 	"github.com/coscene-io/cocli/internal/prompts"
 	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -39,11 +40,7 @@ func NewMoveCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 		Args:                  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 
 			// Get working project.
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)

--- a/pkg/cmd/record/update.go
+++ b/pkg/cmd/record/update.go
@@ -56,7 +56,11 @@ func NewUpdateCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/update.go
+++ b/pkg/cmd/record/update.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coscene-io/cocli/internal/customfield"
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	"github.com/coscene-io/cocli/pkg/cmd_utils/upload_utils"
 	mapset "github.com/deckarep/golang-set/v2"
 	log "github.com/sirupsen/logrus"
@@ -56,11 +57,7 @@ func NewUpdateCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/upload.go
+++ b/pkg/cmd/record/upload.go
@@ -43,7 +43,11 @@ func NewUploadCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func
 		Args:                  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/upload.go
+++ b/pkg/cmd/record/upload.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	"github.com/coscene-io/cocli/pkg/cmd_utils/upload_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -43,11 +44,7 @@ func NewUploadCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func
 		Args:                  cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/view.go
+++ b/pkg/cmd/record/view.go
@@ -38,7 +38,11 @@ func NewViewCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/record/view.go
+++ b/pkg/cmd/record/view.go
@@ -21,6 +21,7 @@ import (
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -38,11 +39,7 @@ func NewViewCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {
 				log.Fatalf("unable to get project name: %v", err)

--- a/pkg/cmd/registry/create_credential.go
+++ b/pkg/cmd/registry/create_credential.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coscene-io/cocli/internal/printer"
 	"github.com/coscene-io/cocli/internal/printer/printable"
 	"github.com/coscene-io/cocli/internal/printer/table"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -33,11 +34,7 @@ func NewCreateCredentialCommand(cfgPath *string, io *iostreams.IOStreams, getPro
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("failed to load profile manager: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			endpoint := pm.GetCurrentProfile().EndPoint
 
 			cred, err := pm.ContainerRegistryCli().CreateBasicCredential(cmd.Context())

--- a/pkg/cmd/registry/create_credential.go
+++ b/pkg/cmd/registry/create_credential.go
@@ -33,7 +33,8 @@ func NewCreateCredentialCommand(cfgPath *string, io *iostreams.IOStreams, getPro
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			pm, err := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
 			if err != nil {
 				log.Fatalf("failed to load profile manager: %v", err)
 			}

--- a/pkg/cmd/registry/login.go
+++ b/pkg/cmd/registry/login.go
@@ -36,7 +36,8 @@ func NewLoginCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			pm, err := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
 			if err != nil {
 				log.Fatalf("failed to load profile manager: %v", err)
 			}

--- a/pkg/cmd/registry/login.go
+++ b/pkg/cmd/registry/login.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -36,11 +37,7 @@ func NewLoginCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("failed to load profile manager: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 
 			endpoint := pm.GetCurrentProfile().EndPoint
 			host, err := inferRegistryHost(endpoint, registry)

--- a/pkg/cmd/role/list.go
+++ b/pkg/cmd/role/list.go
@@ -21,6 +21,7 @@ import (
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/printer"
 	"github.com/coscene-io/cocli/internal/printer/printable"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -47,15 +48,7 @@ func NewListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 				log.Fatalf("--page-size must be between 10 and 100")
 			}
 
-			profileOverride, _ := cmd.Flags().GetString("profile")
-
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-
-			if err != nil {
-
-				log.Fatalf("Failed to resolve profile: %v", err)
-
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 
 			effectivePageSize := int32(pageSize)
 			if effectivePageSize <= 0 {

--- a/pkg/cmd/role/list.go
+++ b/pkg/cmd/role/list.go
@@ -47,7 +47,15 @@ func NewListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 				log.Fatalf("--page-size must be between 10 and 100")
 			}
 
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+
+			if err != nil {
+
+				log.Fatalf("Failed to resolve profile: %v", err)
+
+			}
 
 			effectivePageSize := int32(pageSize)
 			if effectivePageSize <= 0 {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -108,6 +108,10 @@ func NewCommand(io *iostreams.IOStreams, getProvider ProviderGetter) *cobra.Comm
 						log.Fatalf("Failed to persist profile manager: %v", err)
 					}
 				}
+				// Stash the resolved (and authenticated) manager so subcommands
+				// reuse it via cmd_utils.ProfileManager instead of re-resolving
+				// and re-authenticating.
+				cmd.SetContext(config.ContextWithProfileManager(cmd.Context(), pm))
 			}
 		},
 	}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -40,8 +40,9 @@ type ProviderGetter func(path string) config.Provider
 
 func NewCommand(io *iostreams.IOStreams, getProvider ProviderGetter) *cobra.Command {
 	var (
-		cfgPath  string
-		logLevel string
+		cfgPath     string
+		logLevel    string
+		profileName string
 	)
 
 	cmd := &cobra.Command{
@@ -83,13 +84,13 @@ func NewCommand(io *iostreams.IOStreams, getProvider ProviderGetter) *cobra.Comm
 			}
 
 			cfg := getProvider(cfgPath)
-			pm, err := cfg.GetProfileManager()
-			if err != nil {
-				log.Fatalf("Failed to get profile manager from config: %v", err)
-			}
 
 			// Auth Check
 			if cmd_utils.IsAuthCheckEnabled(cmd) {
+				pm, ephemeral, err := config.ResolveProfileManager(cmd.Context(), cfg, profileName)
+				if err != nil {
+					log.Fatalf("Failed to resolve profile: %v", err)
+				}
 				if pm.IsEmpty() {
 					io.Eprintf("Config file is empty, please run `cocli login set` to initialize your login profile.\n")
 					os.Exit(0)
@@ -98,7 +99,11 @@ func NewCommand(io *iostreams.IOStreams, getProvider ProviderGetter) *cobra.Comm
 					if err = pm.Auth(cmd.Context()); err != nil {
 						log.Fatalf("Failed to authenticate current login profile: %v", err)
 					}
-
+				}
+				// Never persist when resolution was driven by --profile or a
+				// COS_* env profile — overrides are in-memory only so concurrent
+				// invocations with different profiles don't clobber the config.
+				if !ephemeral {
 					if err = cfg.Persist(pm); err != nil {
 						log.Fatalf("Failed to persist profile manager: %v", err)
 					}
@@ -108,6 +113,7 @@ func NewCommand(io *iostreams.IOStreams, getProvider ProviderGetter) *cobra.Comm
 	}
 	cmd.PersistentFlags().StringVar(&cfgPath, "config", constants.DefaultConfigPath, "config file path")
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "log level, one of: trace|debug|info|warn|error")
+	cmd.PersistentFlags().StringVar(&profileName, "profile", "", "profile to use for this invocation (overrides config current-profile; in-memory only, not persisted; ignored by login commands)")
 
 	cmd.AddCommand(NewCompletionCommand())
 	cmd.AddCommand(action.NewRootCommand(&cfgPath, io, getProvider))

--- a/pkg/cmd/user/get.go
+++ b/pkg/cmd/user/get.go
@@ -41,7 +41,11 @@ func NewGetCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+			if err != nil {
+				log.Fatalf("Failed to resolve profile: %v", err)
+			}
 
 			userName := "users/current"
 			if len(args) == 1 {

--- a/pkg/cmd/user/get.go
+++ b/pkg/cmd/user/get.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coscene-io/cocli/internal/printer"
 	"github.com/coscene-io/cocli/internal/printer/printable"
 	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -41,11 +42,7 @@ func NewGetCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			profileOverride, _ := cmd.Flags().GetString("profile")
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-			if err != nil {
-				log.Fatalf("Failed to resolve profile: %v", err)
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 
 			userName := "users/current"
 			if len(args) == 1 {

--- a/pkg/cmd/user/list.go
+++ b/pkg/cmd/user/list.go
@@ -21,6 +21,7 @@ import (
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/printer"
 	"github.com/coscene-io/cocli/internal/printer/printable"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -45,15 +46,7 @@ func NewListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 				log.Fatalf("--page-size must be between 10 and 100")
 			}
 
-			profileOverride, _ := cmd.Flags().GetString("profile")
-
-			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
-
-			if err != nil {
-
-				log.Fatalf("Failed to resolve profile: %v", err)
-
-			}
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 
 			parent := ""
 			if projectSlug != "" {

--- a/pkg/cmd/user/list.go
+++ b/pkg/cmd/user/list.go
@@ -45,7 +45,15 @@ func NewListCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 				log.Fatalf("--page-size must be between 10 and 100")
 			}
 
-			pm, _ := getProvider(*cfgPath).GetProfileManager()
+			profileOverride, _ := cmd.Flags().GetString("profile")
+
+			pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(*cfgPath), profileOverride)
+
+			if err != nil {
+
+				log.Fatalf("Failed to resolve profile: %v", err)
+
+			}
 
 			parent := ""
 			if projectSlug != "" {

--- a/pkg/cmd_utils/profile.go
+++ b/pkg/cmd_utils/profile.go
@@ -1,0 +1,42 @@
+// Copyright 2024 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd_utils
+
+import (
+	"github.com/coscene-io/cocli/internal/config"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// ProfileManager returns the resolved profile manager for a command.
+//
+// When the root PersistentPreRun has already resolved and stashed the manager
+// on the command context (the common, auth-checked path), that instance is
+// reused — avoiding a second resolution and a redundant network authentication.
+// For commands that skip the root auth check (e.g. registry), it resolves now,
+// honoring the global --profile flag and COS_* env precedence. On a resolution
+// error (e.g. --profile names an unknown profile) it logs fatally, surfacing the
+// clear message rather than letting callers dereference a nil manager.
+func ProfileManager(cmd *cobra.Command, getProvider func(string) config.Provider, cfgPath string) *config.ProfileManager {
+	if pm, ok := config.ProfileManagerFromContext(cmd.Context()); ok {
+		return pm
+	}
+	override, _ := cmd.Flags().GetString("profile")
+	pm, _, err := config.ResolveProfileManager(cmd.Context(), getProvider(cfgPath), override)
+	if err != nil {
+		log.Fatalf("Failed to resolve profile: %v", err)
+	}
+	return pm
+}


### PR DESCRIPTION
## What

Adds a global \`--profile\` flag so a single command can target a different profile without changing the persisted \`current-profile\`. Enables using multiple profiles concurrently.

## Precedence

\`\`\`
--profile NAME  >  complete COS_* env  >  config current-profile
\`\`\`

- \`--profile NAME\` selects a named config profile (hard error if absent).
- A complete \`COS_*\` env set (\`COS_ENDPOINT\`+\`COS_TOKEN\`+\`COS_PROJECT\`, optional \`COS_PROJECTID\`) forms a one-off ephemeral profile; partial set is ignored.
- Otherwise the config \`current-profile\` is used.

## Design

- New \`ResolveProfileManager\` centralizes precedence and authenticates ephemeral profiles in memory.
- \`GetProfileManager\` is now config-only; env-inject logic moved into the resolver.
- **Overrides are in-memory only** — root \`PersistentPreRun\` skips \`Persist\` when resolution is ephemeral, so concurrent \`--profile\`/\`COS_*\` runs never clobber the shared config.
- \`login\` subcommands bypass the override (they own the config).
- \`--profile\` rides cobra persistent-flag inheritance (\`cmd.Flags().GetString("profile")\`) — no constructor threading.

## Robustness

- Env-built profiles are validated (endpoint prefix), matching prior behavior.
- \`COS_NAME\` can no longer alias the \`ENV_LOADED_PROFILE\` sentinel.
- \`Profile.CheckAuth\` is nil-safe.
- Data-plane commands surface resolver errors instead of nil-deref.

## Tests / gates

- New \`internal/config/resolve_test.go\` covering the full precedence matrix + env builder.
- \`go build ./...\`, \`go vet ./...\`, full \`go test ./...\` pass; gofmt clean.

## Follow-ups (deferred, not blocking)

- Resolve-once: stash resolved pm on \`cmd.Context()\` in root PreRun so leaves don't re-resolve+re-auth (also stops registry commands being forced into org/project auth despite \`DisableAuthCheck\`).
- Cache authed Org/ProjectName back to a named profile under \`--profile NAME\`.
- Extract a \`ResolveFromCmd\` helper to collapse the ~27-site idiom.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coCLI/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785391517&installation_id=141984720&pr_number=182&repository=coscene-io%2FcoCLI&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoCLI%2Fpull%2F182&signature=bb9a53d6e561d4878be7c16c6ec53d63698e0b0f61d1f3e30d69b200f67ecb1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->