### PR TITLE
fix(action logs): stream DAG node logs with prefixes

### DIFF
--- a/pkg/cmd/action/logs.go
+++ b/pkg/cmd/action/logs.go
@@ -16,12 +16,14 @@ package action
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	openv1alpha1enums "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/enums"
@@ -33,6 +35,7 @@ import (
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/name"
 	"github.com/coscene-io/cocli/pkg/cmd_utils"
+	"github.com/mattn/go-runewidth"
 	"github.com/spf13/cobra"
 )
 
@@ -65,8 +68,8 @@ of whether the run is in progress or already completed.
 
   -j  select which job run to read when an action run has several
       (default 0 = the first).
-  --node  select a node to read for multi-node (DAG) job runs; not needed
-      for single-step jobs.
+  --node  only read this DAG node. When omitted, all DAG nodes are printed
+      in dependency order.
   -f  follow: keep the stream open and reconnect on transient errors. If
       the job run has not started yet, wait for it to start. Without -f, a
       not-yet-started run is reported and the command exits.`,
@@ -76,7 +79,7 @@ of whether the run is in progress or already completed.
   # By bare UUID, following a running job and waiting if it hasn't started
   cocli action logs <uuid> -p my-project -f
 
-  # A specific job run and DAG node
+  # A specific job run and DAG node; output still includes the node prefix
   cocli action logs <uuid> -p my-project -j 1 --node encode`,
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(1),
@@ -122,21 +125,20 @@ of whether the run is in progress or already completed.
 				return
 			}
 
-			resolvedNode, err := resolveLogNode(cmd.Context(), cli, jobRunName, node)
+			nodes, err := resolveLogNodes(cmd.Context(), cli, jobRunName, node)
 			if err != nil {
-				if errors.Is(err, context.Canceled) {
-					return
-				}
 				exitf(io, "%v", err)
 				return
 			}
-			streamFn := func(ctx context.Context, n string) error {
-				return streamOnce(ctx, cli, jobRunName, n, io)
+			if len(nodes) == 0 {
+				io.Println("No nodes found for this job run.")
+				return
 			}
-			dagFn := func(ctx context.Context) (string, error) {
-				return resolveDefaultNode(ctx, cli, jobRunName)
+
+			streamFn := func(ctx context.Context, n string, nodeIO *iostreams.IOStreams) error {
+				return streamOnce(ctx, cli, jobRunName, n, nodeIO)
 			}
-			if err = followLogs(cmd.Context(), resolvedNode, follow, io, streamFn, dagFn); err != nil {
+			if err = followLogs(cmd.Context(), nodes, follow, io, streamFn); err != nil {
 				if errors.Is(err, context.Canceled) {
 					return // clean Ctrl-C exit
 				}
@@ -147,7 +149,7 @@ of whether the run is in progress or already completed.
 
 	cmd.Flags().StringVarP(&projectSlug, "project", "p", "", "working project slug")
 	cmd.Flags().IntVarP(&jobIndex, "job", "j", 0, "index of the job run to stream (default 0 = first)")
-	cmd.Flags().StringVar(&node, "node", "", "DAG node to stream (default: the only/first node)")
+	cmd.Flags().StringVar(&node, "node", "", "DAG node to stream (default: all nodes in dependency order)")
 	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "follow the log stream (reconnect on transient errors)")
 
 	return cmd
@@ -258,38 +260,58 @@ func awaitJobRunStart(
 	}
 }
 
-// followLogs drives the log stream state machine: it resolves the DAG node when
-// an empty node is rejected (multi-node workflows) and reconnects on transient
-// errors when follow is set. streamFn opens and relays a single stream for the
-// given node; dagFn resolves the default node. Both are injected for testability.
+// followLogs streams each selected node in order. Every stdout log line is
+// prefixed with the node name, aligned to the widest selected node.
 func followLogs(
+	ctx context.Context,
+	nodes []string,
+	follow bool,
+	io *iostreams.IOStreams,
+	streamFn func(ctx context.Context, node string, nodeIO *iostreams.IOStreams) error,
+) error {
+	width := maxNodeNameWidth(nodes)
+	for _, node := range nodes {
+		nodeIO := withNodePrefix(io, node, width)
+		if err := followNodeLogs(ctx, node, follow, io, nodeIO, streamFn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func followNodeLogs(
 	ctx context.Context,
 	node string,
 	follow bool,
 	io *iostreams.IOStreams,
-	streamFn func(ctx context.Context, node string) error,
-	dagFn func(ctx context.Context) (string, error),
+	nodeIO *iostreams.IOStreams,
+	streamFn func(ctx context.Context, node string, nodeIO *iostreams.IOStreams) error,
 ) error {
-	resolvedNode := node
 	delay := reconnectBaseDelay
 
 	for attempt := 0; ; attempt++ {
-		err := streamFn(ctx, resolvedNode)
+		err := streamFn(ctx, node, nodeIO)
 		switch {
 		case err == nil:
 			return nil // stream ended cleanly (job finished)
 		case errors.Is(err, context.Canceled):
 			return context.Canceled
-		case isNodeNotFound(err) && resolvedNode == "":
-			// Multi-node (Steps) workflow: empty node is rejected. Resolve via DAG.
-			n, resolveErr := dagFn(ctx)
-			if resolveErr != nil {
-				return resolveErr
+		case isNodeNotFound(err):
+			if !follow {
+				io.Eprintln(fmt.Sprintf("No logs available for node %q yet; pass -f to wait.", node))
+				return nil
 			}
-			resolvedNode = n
-			continue
+			if attempt < reconnectMaxAttempts {
+				io.Eprintln(fmt.Sprintf("Waiting for logs from node %q... (attempt %d/%d)", node, attempt+1, reconnectMaxAttempts))
+				if sleepErr := sleepCtx(ctx, delay); sleepErr != nil {
+					return sleepErr
+				}
+				delay = nextDelay(delay)
+				continue
+			}
+			return err
 		case follow && isRetriable(err) && attempt < reconnectMaxAttempts:
-			io.Eprintln(fmt.Sprintf("Stream interrupted, reconnecting... (attempt %d/%d): %v", attempt+1, reconnectMaxAttempts, err))
+			io.Eprintln(fmt.Sprintf("Stream for node %q interrupted, reconnecting... (attempt %d/%d): %v", node, attempt+1, reconnectMaxAttempts, err))
 			if sleepErr := sleepCtx(ctx, delay); sleepErr != nil {
 				return sleepErr
 			}
@@ -319,21 +341,6 @@ func streamOnce(ctx context.Context, cli api.JobRunInterface, jobRunName, node s
 		}
 	}
 	return stream.Err()
-}
-
-func resolveLogNode(ctx context.Context, cli api.JobRunInterface, jobRunName, node string) (string, error) {
-	dag, err := cli.GetJobRunDag(ctx, jobRunName)
-	if err != nil {
-		return "", err
-	}
-	nodes := dag.GetNodes()
-	if node != "" {
-		if _, ok := nodes[node]; ok {
-			return node, nil
-		}
-		return "", fmt.Errorf("job run node %q not found. Available: %v", node, nodeNames(nodes))
-	}
-	return resolveDefaultNodeFromNodes(nodes)
 }
 
 // handleLogMessage renders one LogJobRun response: a live log line (message),
@@ -384,31 +391,141 @@ func printArchivedLog(ctx context.Context, downloadURL string, io *iostreams.IOS
 	return nil
 }
 
-// resolveDefaultNode picks a node name when the job run is a multi-node DAG.
-func resolveDefaultNode(ctx context.Context, cli api.JobRunInterface, jobRunName string) (string, error) {
+// resolveLogNodes resolves the nodes that should be streamed. Explicit --node
+// selection keeps the command scoped to that node; the default is the whole DAG
+// in dependency order.
+func resolveLogNodes(ctx context.Context, cli api.JobRunInterface, jobRunName string, requestedNode string) ([]string, error) {
 	dag, err := cli.GetJobRunDag(ctx, jobRunName)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return resolveDefaultNodeFromNodes(dag.GetNodes())
-}
-
-func resolveDefaultNodeFromNodes(nodes map[string]*openv1alpha1resource.JobRunNode) (string, error) {
-	if len(nodes) == 1 {
-		for nodeName := range nodes {
-			return nodeName, nil
+	nodes := dag.GetNodes()
+	if requestedNode != "" {
+		if _, ok := nodes[requestedNode]; ok {
+			return []string{requestedNode}, nil
 		}
+		return nil, fmt.Errorf("job run node %q not found. Available: %v", requestedNode, nodeNames(nodes))
 	}
-	return "", fmt.Errorf("job run has multiple nodes; specify one with --node. Available: %v", nodeNames(nodes))
+	return sortDagNodes(nodes)
 }
 
 func nodeNames(nodes map[string]*openv1alpha1resource.JobRunNode) []string {
+	names := make([]string, 0, len(nodes))
+	for nodeName := range nodes {
+		names = append(names, nodeName)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortDagNodes(nodes map[string]*openv1alpha1resource.JobRunNode) ([]string, error) {
 	nodeNames := make([]string, 0, len(nodes))
+	indegree := make(map[string]int, len(nodes))
+	dependents := make(map[string][]string, len(nodes))
+
 	for nodeName := range nodes {
 		nodeNames = append(nodeNames, nodeName)
+		indegree[nodeName] = 0
 	}
 	sort.Strings(nodeNames)
-	return nodeNames
+
+	for _, nodeName := range nodeNames {
+		for _, dep := range nodes[nodeName].GetDependentNodes() {
+			if _, ok := nodes[dep]; !ok {
+				continue
+			}
+			indegree[nodeName]++
+			dependents[dep] = append(dependents[dep], nodeName)
+		}
+	}
+	for dep := range dependents {
+		sort.Strings(dependents[dep])
+	}
+
+	queue := make([]string, 0, len(nodes))
+	for _, nodeName := range nodeNames {
+		if indegree[nodeName] == 0 {
+			queue = append(queue, nodeName)
+		}
+	}
+
+	ordered := make([]string, 0, len(nodes))
+	for len(queue) > 0 {
+		nodeName := queue[0]
+		queue = queue[1:]
+		ordered = append(ordered, nodeName)
+
+		for _, dependent := range dependents[nodeName] {
+			indegree[dependent]--
+			if indegree[dependent] == 0 {
+				queue = append(queue, dependent)
+			}
+		}
+		sort.Strings(queue)
+	}
+
+	if len(ordered) != len(nodes) {
+		return nil, fmt.Errorf("job run DAG contains a dependency cycle")
+	}
+	return ordered, nil
+}
+
+func maxNodeNameWidth(nodes []string) int {
+	width := 0
+	for _, node := range nodes {
+		width = max(width, runewidth.StringWidth(node))
+	}
+	return width
+}
+
+func withNodePrefix(io *iostreams.IOStreams, node string, width int) *iostreams.IOStreams {
+	return iostreams.Test(io.In, &nodePrefixWriter{
+		out:         io.Out,
+		prefix:      padNodeName(node, width) + "  ",
+		atLineStart: true,
+	}, io.ErrOut)
+}
+
+func padNodeName(node string, width int) string {
+	padding := width - runewidth.StringWidth(node)
+	if padding <= 0 {
+		return node
+	}
+	return node + strings.Repeat(" ", padding)
+}
+
+type nodePrefixWriter struct {
+	out         interface{ Write([]byte) (int, error) }
+	prefix      string
+	atLineStart bool
+}
+
+func (w *nodePrefixWriter) Write(p []byte) (int, error) {
+	originalLen := len(p)
+	for len(p) > 0 {
+		if w.atLineStart {
+			if _, err := fmt.Fprint(w.out, w.prefix); err != nil {
+				return 0, err
+			}
+			w.atLineStart = false
+		}
+
+		newline := bytes.IndexByte(p, '\n')
+		if newline == -1 {
+			if _, err := w.out.Write(p); err != nil {
+				return 0, err
+			}
+			return originalLen, nil
+		}
+
+		if _, err := w.out.Write(p[:newline+1]); err != nil {
+			return 0, err
+		}
+		w.atLineStart = true
+		p = p[newline+1:]
+	}
+
+	return originalLen, nil
 }
 
 func isNodeNotFound(err error) bool {

--- a/pkg/cmd/action/logs_test.go
+++ b/pkg/cmd/action/logs_test.go
@@ -234,10 +234,9 @@ func TestAwaitJobRunStart_FollowCanceled(t *testing.T) {
 
 func TestFollowLogs_CleanEnd(t *testing.T) {
 	calls := 0
-	streamFn := func(_ context.Context, _ string) error { calls++; return nil }
-	dagFn := func(_ context.Context) (string, error) { return "", nil }
+	streamFn := func(_ context.Context, _ string, _ *iostreams.IOStreams) error { calls++; return nil }
 
-	if err := followLogs(context.Background(), "", false, discardIO(), streamFn, dagFn); err != nil {
+	if err := followLogs(context.Background(), []string{"n"}, false, discardIO(), streamFn); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if calls != 1 {
@@ -246,42 +245,41 @@ func TestFollowLogs_CleanEnd(t *testing.T) {
 }
 
 func TestFollowLogs_CanceledExitsClean(t *testing.T) {
-	streamFn := func(_ context.Context, _ string) error { return context.Canceled }
-	dagFn := func(_ context.Context) (string, error) { return "", nil }
+	streamFn := func(_ context.Context, _ string, _ *iostreams.IOStreams) error { return context.Canceled }
 
-	err := followLogs(context.Background(), "", true, discardIO(), streamFn, dagFn)
+	err := followLogs(context.Background(), []string{"n"}, true, discardIO(), streamFn)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("want context.Canceled, got %v", err)
 	}
 }
 
-func TestFollowLogs_NodeNotFoundResolvesViaDag(t *testing.T) {
-	var nodes []string
-	streamFn := func(_ context.Context, node string) error {
-		nodes = append(nodes, node)
-		if node == "" {
-			return connect.NewError(connect.CodeInvalidArgument, errors.New("pod node not found"))
-		}
-		return nil // succeeds once a real node is supplied
+func TestFollowLogs_NodeNotFoundWithoutFollowSkipsNode(t *testing.T) {
+	calls := 0
+	var errOut bytes.Buffer
+	io := iostreams.Test(nil, &discardWriter{}, &errOut)
+	streamFn := func(_ context.Context, _ string, _ *iostreams.IOStreams) error {
+		calls++
+		return connect.NewError(connect.CodeInvalidArgument, errors.New("pod node not found"))
 	}
-	dagFn := func(_ context.Context) (string, error) { return "resolved-node", nil }
 
-	if err := followLogs(context.Background(), "", false, discardIO(), streamFn, dagFn); err != nil {
+	if err := followLogs(context.Background(), []string{"pending"}, false, io, streamFn); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(nodes) != 2 || nodes[0] != "" || nodes[1] != "resolved-node" {
-		t.Fatalf("unexpected node sequence: %v", nodes)
+	if calls != 1 {
+		t.Fatalf("streamFn calls = %d, want 1", calls)
+	}
+	if !strings.Contains(errOut.String(), `node "pending"`) {
+		t.Fatalf("expected node-specific stderr, got %q", errOut.String())
 	}
 }
 
 func TestFollowLogs_NonRetriableReturns(t *testing.T) {
-	wantErr := connect.NewError(connect.CodeNotFound, errors.New("gone"))
-	streamFn := func(_ context.Context, _ string) error { return wantErr }
-	dagFn := func(_ context.Context) (string, error) { return "", nil }
+	wantErr := connect.NewError(connect.CodeUnauthenticated, errors.New("nope"))
+	streamFn := func(_ context.Context, _ string, _ *iostreams.IOStreams) error { return wantErr }
 
-	err := followLogs(context.Background(), "n", true, discardIO(), streamFn, dagFn)
-	if connect.CodeOf(err) != connect.CodeNotFound {
-		t.Fatalf("want NotFound, got %v", err)
+	err := followLogs(context.Background(), []string{"n"}, true, discardIO(), streamFn)
+	if connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Fatalf("want Unauthenticated, got %v", err)
 	}
 }
 
@@ -290,35 +288,27 @@ func TestFollowLogs_RetriableReconnectStopsOnCanceledBackoff(t *testing.T) {
 	// the reconnect branch without a real delay.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	streamFn := func(_ context.Context, _ string) error {
+	streamFn := func(_ context.Context, _ string, _ *iostreams.IOStreams) error {
 		return connect.NewError(connect.CodeUnavailable, errors.New("flaky"))
 	}
-	dagFn := func(_ context.Context) (string, error) { return "", nil }
 
-	err := followLogs(ctx, "n", true, discardIO(), streamFn, dagFn)
+	err := followLogs(ctx, []string{"n"}, true, discardIO(), streamFn)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("want context.Canceled from backoff, got %v", err)
 	}
 }
 
-func TestResolveLogNode(t *testing.T) {
+func TestResolveLogNodes(t *testing.T) {
 	t.Run("explicit node validates against dag", func(t *testing.T) {
 		cli := &fakeJobRunClient{dag: &openv1alpha1resource.JobRunDag{
 			Nodes: map[string]*openv1alpha1resource.JobRunNode{"echo": {Name: "echo"}},
 		}}
-		got, err := resolveLogNode(context.Background(), cli, "jr", "echo")
-		if err != nil || got != "echo" {
-			t.Fatalf("got %q, err %v", got, err)
+		got, err := resolveLogNodes(context.Background(), cli, "jr", "echo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
-	})
-
-	t.Run("empty node resolves from dag", func(t *testing.T) {
-		cli := &fakeJobRunClient{dag: &openv1alpha1resource.JobRunDag{
-			Nodes: map[string]*openv1alpha1resource.JobRunNode{"echo": {Name: "echo"}},
-		}}
-		got, err := resolveLogNode(context.Background(), cli, "jr", "")
-		if err != nil || got != "echo" {
-			t.Fatalf("got %q, err %v", got, err)
+		if strings.Join(got, ",") != "echo" {
+			t.Fatalf("got %v, want [echo]", got)
 		}
 	})
 
@@ -326,38 +316,132 @@ func TestResolveLogNode(t *testing.T) {
 		cli := &fakeJobRunClient{dag: &openv1alpha1resource.JobRunDag{
 			Nodes: map[string]*openv1alpha1resource.JobRunNode{"echo": {Name: "echo"}},
 		}}
-		_, err := resolveLogNode(context.Background(), cli, "jr", "missing")
+		_, err := resolveLogNodes(context.Background(), cli, "jr", "missing")
 		if err == nil || !strings.Contains(err.Error(), `job run node "missing" not found`) ||
 			!strings.Contains(err.Error(), "Available: [echo]") {
 			t.Fatalf("expected invalid node error with available nodes, got %v", err)
 		}
 	})
-}
 
-func TestResolveDefaultNode(t *testing.T) {
-	t.Run("single node auto-filled", func(t *testing.T) {
+	t.Run("dependency order", func(t *testing.T) {
 		cli := &fakeJobRunClient{dag: &openv1alpha1resource.JobRunDag{
-			Nodes: map[string]*openv1alpha1resource.JobRunNode{"only": {Name: "only"}},
+			Nodes: map[string]*openv1alpha1resource.JobRunNode{
+				"c": {Name: "c", DependentNodes: []string{"b"}},
+				"a": {Name: "a"},
+				"b": {Name: "b", DependentNodes: []string{"a"}},
+			},
 		}}
-		got, err := resolveDefaultNode(context.Background(), cli, "jr")
-		if err != nil || got != "only" {
-			t.Fatalf("got %q, err %v", got, err)
+		got, err := resolveLogNodes(context.Background(), cli, "jr", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Join(got, ",") != "a,b,c" {
+			t.Fatalf("got %v, want [a b c]", got)
 		}
 	})
 
-	t.Run("multiple nodes errors", func(t *testing.T) {
+	t.Run("parallel layer sorted by name", func(t *testing.T) {
 		cli := &fakeJobRunClient{dag: &openv1alpha1resource.JobRunDag{
-			Nodes: map[string]*openv1alpha1resource.JobRunNode{"a": {}, "b": {}},
+			Nodes: map[string]*openv1alpha1resource.JobRunNode{
+				"z": {Name: "z"},
+				"a": {Name: "a"},
+				"m": {Name: "m", DependentNodes: []string{"a", "z"}},
+			},
 		}}
-		if _, err := resolveDefaultNode(context.Background(), cli, "jr"); err == nil {
-			t.Fatal("expected error for multiple nodes")
+		got, err := resolveLogNodes(context.Background(), cli, "jr", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Join(got, ",") != "a,z,m" {
+			t.Fatalf("got %v, want [a z m]", got)
+		}
+	})
+
+	t.Run("missing dependencies ignored", func(t *testing.T) {
+		cli := &fakeJobRunClient{dag: &openv1alpha1resource.JobRunDag{
+			Nodes: map[string]*openv1alpha1resource.JobRunNode{
+				"b": {Name: "b", DependentNodes: []string{"missing"}},
+				"a": {Name: "a"},
+			},
+		}}
+		got, err := resolveLogNodes(context.Background(), cli, "jr", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Join(got, ",") != "a,b" {
+			t.Fatalf("got %v, want [a b]", got)
+		}
+	})
+
+	t.Run("cycle errors", func(t *testing.T) {
+		cli := &fakeJobRunClient{dag: &openv1alpha1resource.JobRunDag{
+			Nodes: map[string]*openv1alpha1resource.JobRunNode{
+				"a": {Name: "a", DependentNodes: []string{"b"}},
+				"b": {Name: "b", DependentNodes: []string{"a"}},
+			},
+		}}
+		_, err := resolveLogNodes(context.Background(), cli, "jr", "")
+		if err == nil || !strings.Contains(err.Error(), "dependency cycle") {
+			t.Fatalf("expected cycle error, got %v", err)
 		}
 	})
 
 	t.Run("dag error propagates", func(t *testing.T) {
 		cli := &fakeJobRunClient{dagErr: errors.New("boom")}
-		if _, err := resolveDefaultNode(context.Background(), cli, "jr"); err == nil {
+		if _, err := resolveLogNodes(context.Background(), cli, "jr", ""); err == nil {
 			t.Fatal("expected dag error")
+		}
+	})
+}
+
+func TestNodePrefixOutput(t *testing.T) {
+	t.Run("live line", func(t *testing.T) {
+		var out bytes.Buffer
+		base := iostreams.Test(nil, &out, &discardWriter{})
+		io := withNodePrefix(base, "b", len("build"))
+		err := handleLogMessage(context.Background(),
+			&openv1alpha1service.LogJobRunResponse{Message: "hello"}, io)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if got, want := out.String(), "b      hello\n"; got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("archived lines", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("line-one\nline-two\n"))
+		}))
+		defer srv.Close()
+
+		var out bytes.Buffer
+		base := iostreams.Test(nil, &out, &discardWriter{})
+		io := withNodePrefix(base, "archive", len("archive"))
+		err := handleLogMessage(context.Background(),
+			&openv1alpha1service.LogJobRunResponse{LogDownloadUri: srv.URL}, io)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if got, want := out.String(), "archive  line-one\narchive  line-two\n"; got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("no logs line", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		var out bytes.Buffer
+		base := iostreams.Test(nil, &out, &discardWriter{})
+		io := withNodePrefix(base, "node", len("node"))
+		if err := printArchivedLog(context.Background(), srv.URL, io); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if !strings.HasPrefix(out.String(), "node  No logs available") {
+			t.Fatalf("expected prefixed no-log line, got %q", out.String())
 		}
 	})
 }


### PR DESCRIPTION
## Summary

`cocli action logs` now handles DAG job runs without requiring users to pick a node first. When `--node` is omitted, the command reads the job-run DAG, orders nodes by dependency, and streams each node with an aligned node-name prefix; when `--node` is provided, the output keeps the same prefix shape while staying scoped to that node.

The command also keeps explicit node validation from `main`, ignores missing dependency references while sorting known nodes, and reports a clear error if the DAG contains a dependency cycle.

## Validation

- `go test ./pkg/cmd/action`
- `go test ./...`
- `go install ./cmd/cocli`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coCLI/pr/183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785408171&installation_id=141984720&pr_number=183&repository=coscene-io%2FcoCLI&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoCLI%2Fpull%2F183&signature=825e8a35d360c98a6d308b3d5756234b71a061be43fca60e2d3032d2fedbd188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->