### PR TITLE
Enforce dev-first branch model

### DIFF
--- a/.github/workflows/enforce-dev-first.yaml
+++ b/.github/workflows/enforce-dev-first.yaml
@@ -1,0 +1,22 @@
+name: Enforce dev-first branch model
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-base:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block PRs to main that don't come from dev
+        run: |
+          HEAD="${{ github.head_ref }}"
+          if [ "$HEAD" != "dev" ]; then
+            echo "::error::PRs to main must come from the dev branch. Got: $HEAD"
+            echo ""
+            echo "Branch model: feature/fix → dev → main"
+            echo "Please retarget this PR to dev, or merge to dev first."
+            exit 1
+          fi
+          echo "✓ PR from dev to main — allowed"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# coCLI
+
+Go CLI (`cocli`) for managing coScene resources from the terminal.
+
+## Branch Model
+
+**All changes go through `dev` first.** Never target `main` directly.
+
+- Feature/fix branches → PR to `dev`
+- Release: `dev` → PR to `main` (creates RC tag, then release tag after verification)
+- Hotfixes: branch from `main`, PR to `dev` first, then cherry-pick to `main` if urgent
+
+When creating a PR with `gh pr create`, always use `--base dev`:
+
+```bash
+gh pr create --base dev --title "..." --body "..."
+```
+
+## Build & Test
+
+```bash
+make build-binary          # build to ./bin/cocli
+go test ./...              # run all tests
+go test ./pkg/cmd/...      # test CLI commands only
+```
+
+## Conventions
+
+- Module: `github.com/coscene-io/cocli`
+- Use `cmd_utils.ProfileManager(cmd, getProvider, cfgPath)` for profile resolution (supports --profile flag and COS_* env)
+- Error handling: `log.Fatalf` for fatal CLI errors
+- Output formats: support `-o table|json|yaml` via `printer.Printer()`


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` that instructs all agents to always PR to `dev`, never `main` directly
- Add GitHub Actions workflow (`enforce-dev-first.yaml`) that blocks any PR to `main` unless it comes from the `dev` branch

## Context
11 PRs (#157–#183) bypassed `dev` and went straight to `main`. This adds two layers of enforcement:

1. **CLAUDE.md** — AI agents (Claude, Codex, etc.) read this before working and will target `dev`
2. **CI check** — any PR to `main` from a non-`dev` branch fails with an error message explaining the process

After merging, mark this check as **required** in GitHub branch protection for `main` to make it a hard gate.

## Test plan
- [ ] Open a test PR from a feature branch to `main` — should fail the check
- [ ] Open a test PR from `dev` to `main` — should pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coCLI/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785415223&installation_id=141984720&pr_number=185&repository=coscene-io%2FcoCLI&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoCLI%2Fpull%2F185&signature=654de24421e44f42e3adfc05d4ecb4be1cbe083d9f4e2d644fc23ac546800bbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->