### PR TITLE
coCLI action get/delete/update

### DIFF
--- a/api/action.go
+++ b/api/action.go
@@ -212,11 +212,18 @@ func (c *actionClient) ActionId2Name(ctx context.Context, actionIdOrName string,
 		return name.NewAction(act.Name)
 	}
 
-	if act, err := c.GetByName(ctx, &name.Action{
+	// Fall back to an org-level lookup. Keep this error: wrapping it with %w
+	// below preserves the underlying connect error chain (e.g. a NotFound code)
+	// so callers can inspect it via utils.IsConnectErrorWithCode / errors.As.
+	// Using %s here would flatten the error to a string and break that guard,
+	// degrading a clean not-found message into a fatal stack (mirror how
+	// RecordId2Name wraps its Get error with errors.Wrapf/%w in api/record.go).
+	act, err := c.GetByName(ctx, &name.Action{
 		ID: actionIdOrName,
-	}); err == nil {
+	})
+	if err == nil {
 		return name.NewAction(act.Name)
 	}
 
-	return nil, fmt.Errorf("failed to convert action id to name: %s", actionIdOrName)
+	return nil, fmt.Errorf("failed to convert action id to name %s: %w", actionIdOrName, err)
 }

--- a/api/action.go
+++ b/api/action.go
@@ -36,6 +36,9 @@ type ActionInterface interface {
 	// ListAllActions lists all actions in the current organization.
 	ListAllActions(ctx context.Context, listOpts *ListActionsOptions) ([]*openv1alpha1resource.Action, error)
 
+	// CreateAction creates an action in a project.
+	CreateAction(ctx context.Context, parent string, action *openv1alpha1resource.Action) (*openv1alpha1resource.Action, error)
+
 	// CreateActionRun creates an action run.
 	CreateActionRun(ctx context.Context, action *openv1alpha1resource.Action, record *name.Record) error
 
@@ -114,6 +117,19 @@ func (c *actionClient) ListAllActions(ctx context.Context, listOpts *ListActions
 
 func (c *actionClient) filter(opt *ListActionsOptions) string {
 	return ""
+}
+
+func (c *actionClient) CreateAction(ctx context.Context, parent string, action *openv1alpha1resource.Action) (*openv1alpha1resource.Action, error) {
+	req := connect.NewRequest(&openv1alpha1service.CreateActionRequest{
+		Parent: parent,
+		Action: action,
+	})
+	res, err := c.actionServiceClient.CreateAction(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create action: %w", err)
+	}
+
+	return res.Msg, nil
 }
 
 func (c *actionClient) CreateActionRun(ctx context.Context, action *openv1alpha1resource.Action, record *name.Record) error {

--- a/api/action.go
+++ b/api/action.go
@@ -27,6 +27,7 @@ import (
 	"github.com/coscene-io/cocli/internal/constants"
 	"github.com/coscene-io/cocli/internal/name"
 	"github.com/samber/lo"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 type ActionInterface interface {
@@ -38,6 +39,15 @@ type ActionInterface interface {
 
 	// CreateAction creates an action in a project.
 	CreateAction(ctx context.Context, parent string, action *openv1alpha1resource.Action) (*openv1alpha1resource.Action, error)
+
+	// UpdateAction updates an action's spec. The name selects the action; only
+	// the fields named in updateMask are written (cocli always sends ["spec"],
+	// which full-replaces the spec — see plan D2/D13).
+	UpdateAction(ctx context.Context, actionName *name.Action, spec *openv1alpha1commons.ActionSpec, updateMask []string) (*openv1alpha1resource.Action, error)
+
+	// DeleteAction deletes an action by name. Delete is a soft delete on the
+	// backend and idempotent (an unknown name still returns success).
+	DeleteAction(ctx context.Context, actionName *name.Action) error
 
 	// CreateActionRun creates an action run.
 	CreateActionRun(ctx context.Context, action *openv1alpha1resource.Action, record *name.Record) error
@@ -130,6 +140,36 @@ func (c *actionClient) CreateAction(ctx context.Context, parent string, action *
 	}
 
 	return res.Msg, nil
+}
+
+func (c *actionClient) UpdateAction(ctx context.Context, actionName *name.Action, spec *openv1alpha1commons.ActionSpec, updateMask []string) (*openv1alpha1resource.Action, error) {
+	req := connect.NewRequest(&openv1alpha1service.UpdateActionRequest{
+		Action: &openv1alpha1resource.Action{
+			Name: actionName.String(),
+			Spec: spec,
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: updateMask,
+		},
+	})
+	res, err := c.actionServiceClient.UpdateAction(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update action: %w", err)
+	}
+
+	return res.Msg, nil
+}
+
+func (c *actionClient) DeleteAction(ctx context.Context, actionName *name.Action) error {
+	req := connect.NewRequest(&openv1alpha1service.DeleteActionRequest{
+		Name: actionName.String(),
+	})
+	_, err := c.actionServiceClient.DeleteAction(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to delete action: %w", err)
+	}
+
+	return nil
 }
 
 func (c *actionClient) CreateActionRun(ctx context.Context, action *openv1alpha1resource.Action, record *name.Record) error {

--- a/api/action_test.go
+++ b/api/action_test.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	openv1alpha1connect "buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go/coscene/openapi/dataplatform/v1alpha1/services/servicesconnect"
@@ -25,6 +26,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/coscene-io/cocli/internal/name"
 	"github.com/coscene-io/cocli/internal/testutil"
+	"github.com/coscene-io/cocli/internal/utils"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -259,5 +261,27 @@ func TestActionClient_ActionId2Name(t *testing.T) {
 		an, err := client.ActionId2Name(ctx, "d9b9d56b-0d43-4719-b7cc-0d7e6616bb8a", proj)
 		require.NoError(t, err)
 		assert.Equal(t, "p1", an.ProjectID)
+	})
+
+	// Regression: a not-found UUID lookup must preserve the underlying connect
+	// error chain through %w so the resolve-first callers (get/delete/update)
+	// can detect NotFound via errors.As / utils.IsConnectErrorWithCode instead
+	// of degrading to a fatal stack. A %s wrap here would flatten the error and
+	// silently break that guard.
+	t.Run("not-found uuid preserves connect NotFound code", func(t *testing.T) {
+		mock := &mockActionServiceClient{
+			ctrl: ctrl,
+			getActionFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.GetActionRequest]) (*connect.Response[openv1alpha1resource.Action], error) {
+				return nil, connect.NewError(connect.CodeNotFound, errors.New("action not found"))
+			},
+		}
+		client := NewActionClient(mock, nil)
+		_, err := client.ActionId2Name(ctx, "d9b9d56b-0d43-4719-b7cc-0d7e6616bb8a", proj)
+		require.Error(t, err)
+
+		var connErr *connect.Error
+		require.True(t, errors.As(err, &connErr), "expected the connect error to survive the wrap")
+		assert.Equal(t, connect.CodeNotFound, connErr.Code())
+		assert.True(t, utils.IsConnectErrorWithCode(err, connect.CodeNotFound))
 	})
 }

--- a/api/action_test.go
+++ b/api/action_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	openv1alpha1connect "buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go/coscene/openapi/dataplatform/v1alpha1/services/servicesconnect"
+	openv1alpha1commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
 	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
 	openv1alpha1service "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/services"
 	"connectrpc.com/connect"
@@ -33,8 +34,9 @@ type mockActionServiceClient struct {
 	openv1alpha1connect.ActionServiceClient
 	ctrl *gomock.Controller
 
-	getActionFunc   func(context.Context, *connect.Request[openv1alpha1service.GetActionRequest]) (*connect.Response[openv1alpha1resource.Action], error)
-	listActionsFunc func(context.Context, *connect.Request[openv1alpha1service.ListActionsRequest]) (*connect.Response[openv1alpha1service.ListActionsResponse], error)
+	getActionFunc    func(context.Context, *connect.Request[openv1alpha1service.GetActionRequest]) (*connect.Response[openv1alpha1resource.Action], error)
+	listActionsFunc  func(context.Context, *connect.Request[openv1alpha1service.ListActionsRequest]) (*connect.Response[openv1alpha1service.ListActionsResponse], error)
+	createActionFunc func(context.Context, *connect.Request[openv1alpha1service.CreateActionRequest]) (*connect.Response[openv1alpha1resource.Action], error)
 }
 
 func (m *mockActionServiceClient) GetAction(ctx context.Context, req *connect.Request[openv1alpha1service.GetActionRequest]) (*connect.Response[openv1alpha1resource.Action], error) {
@@ -47,6 +49,13 @@ func (m *mockActionServiceClient) GetAction(ctx context.Context, req *connect.Re
 func (m *mockActionServiceClient) ListActions(ctx context.Context, req *connect.Request[openv1alpha1service.ListActionsRequest]) (*connect.Response[openv1alpha1service.ListActionsResponse], error) {
 	if m.listActionsFunc != nil {
 		return m.listActionsFunc(ctx, req)
+	}
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+
+func (m *mockActionServiceClient) CreateAction(ctx context.Context, req *connect.Request[openv1alpha1service.CreateActionRequest]) (*connect.Response[openv1alpha1resource.Action], error) {
+	if m.createActionFunc != nil {
+		return m.createActionFunc(ctx, req)
 	}
 	return nil, connect.NewError(connect.CodeUnimplemented, nil)
 }
@@ -118,6 +127,46 @@ func TestActionClient_ListAllActions(t *testing.T) {
 		}
 		client := NewActionClient(mock, nil)
 		_, err := client.ListAllActions(ctx, &ListActionsOptions{Parent: "projects/p1"})
+		assert.Error(t, err)
+	})
+}
+
+func TestActionClient_CreateAction(t *testing.T) {
+	ctx := testutil.TestContext(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("success", func(t *testing.T) {
+		input := &openv1alpha1resource.Action{
+			Spec: &openv1alpha1commons.ActionSpec{Name: "diagnose", Jobs: []*openv1alpha1commons.JobSpec{{Name: "job"}}},
+		}
+		expected := &openv1alpha1resource.Action{
+			Name: "projects/p1/actions/a1",
+			Spec: input.Spec,
+		}
+		mock := &mockActionServiceClient{
+			ctrl: ctrl,
+			createActionFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.CreateActionRequest]) (*connect.Response[openv1alpha1resource.Action], error) {
+				assert.Equal(t, "projects/p1", req.Msg.Parent)
+				assert.Equal(t, input, req.Msg.Action)
+				return connect.NewResponse(expected), nil
+			},
+		}
+		client := NewActionClient(mock, nil)
+		action, err := client.CreateAction(ctx, "projects/p1", input)
+		require.NoError(t, err)
+		assert.Equal(t, expected, action)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		mock := &mockActionServiceClient{
+			ctrl: ctrl,
+			createActionFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.CreateActionRequest]) (*connect.Response[openv1alpha1resource.Action], error) {
+				return nil, connect.NewError(connect.CodePermissionDenied, nil)
+			},
+		}
+		client := NewActionClient(mock, nil)
+		_, err := client.CreateAction(ctx, "projects/p1", &openv1alpha1resource.Action{})
 		assert.Error(t, err)
 	})
 }

--- a/api/action_test.go
+++ b/api/action_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type mockActionServiceClient struct {
@@ -39,6 +40,8 @@ type mockActionServiceClient struct {
 	getActionFunc    func(context.Context, *connect.Request[openv1alpha1service.GetActionRequest]) (*connect.Response[openv1alpha1resource.Action], error)
 	listActionsFunc  func(context.Context, *connect.Request[openv1alpha1service.ListActionsRequest]) (*connect.Response[openv1alpha1service.ListActionsResponse], error)
 	createActionFunc func(context.Context, *connect.Request[openv1alpha1service.CreateActionRequest]) (*connect.Response[openv1alpha1resource.Action], error)
+	updateActionFunc func(context.Context, *connect.Request[openv1alpha1service.UpdateActionRequest]) (*connect.Response[openv1alpha1resource.Action], error)
+	deleteActionFunc func(context.Context, *connect.Request[openv1alpha1service.DeleteActionRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
 func (m *mockActionServiceClient) GetAction(ctx context.Context, req *connect.Request[openv1alpha1service.GetActionRequest]) (*connect.Response[openv1alpha1resource.Action], error) {
@@ -58,6 +61,20 @@ func (m *mockActionServiceClient) ListActions(ctx context.Context, req *connect.
 func (m *mockActionServiceClient) CreateAction(ctx context.Context, req *connect.Request[openv1alpha1service.CreateActionRequest]) (*connect.Response[openv1alpha1resource.Action], error) {
 	if m.createActionFunc != nil {
 		return m.createActionFunc(ctx, req)
+	}
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+
+func (m *mockActionServiceClient) UpdateAction(ctx context.Context, req *connect.Request[openv1alpha1service.UpdateActionRequest]) (*connect.Response[openv1alpha1resource.Action], error) {
+	if m.updateActionFunc != nil {
+		return m.updateActionFunc(ctx, req)
+	}
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+
+func (m *mockActionServiceClient) DeleteAction(ctx context.Context, req *connect.Request[openv1alpha1service.DeleteActionRequest]) (*connect.Response[emptypb.Empty], error) {
+	if m.deleteActionFunc != nil {
+		return m.deleteActionFunc(ctx, req)
 	}
 	return nil, connect.NewError(connect.CodeUnimplemented, nil)
 }
@@ -170,6 +187,81 @@ func TestActionClient_CreateAction(t *testing.T) {
 		client := NewActionClient(mock, nil)
 		_, err := client.CreateAction(ctx, "projects/p1", &openv1alpha1resource.Action{})
 		assert.Error(t, err)
+	})
+}
+
+func TestActionClient_UpdateAction(t *testing.T) {
+	ctx := testutil.TestContext(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	actionName := &name.Action{ProjectID: "p1", ID: "a1"}
+	spec := &openv1alpha1commons.ActionSpec{Name: "diagnose", Jobs: []*openv1alpha1commons.JobSpec{{Name: "main"}}}
+
+	t.Run("success sends action name, spec and update_mask", func(t *testing.T) {
+		expected := &openv1alpha1resource.Action{Name: "projects/p1/actions/a1", Spec: spec}
+		mock := &mockActionServiceClient{
+			ctrl: ctrl,
+			updateActionFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.UpdateActionRequest]) (*connect.Response[openv1alpha1resource.Action], error) {
+				require.NotNil(t, req.Msg.Action)
+				assert.Equal(t, "projects/p1/actions/a1", req.Msg.Action.Name)
+				assert.Equal(t, spec, req.Msg.Action.Spec)
+				require.NotNil(t, req.Msg.UpdateMask)
+				assert.Equal(t, []string{"spec"}, req.Msg.UpdateMask.Paths)
+				return connect.NewResponse(expected), nil
+			},
+		}
+		client := NewActionClient(mock, nil)
+		got, err := client.UpdateAction(ctx, actionName, spec, []string{"spec"})
+		require.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("error is wrapped preserving connect code", func(t *testing.T) {
+		mock := &mockActionServiceClient{
+			ctrl: ctrl,
+			updateActionFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.UpdateActionRequest]) (*connect.Response[openv1alpha1resource.Action], error) {
+				return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("bad spec"))
+			},
+		}
+		client := NewActionClient(mock, nil)
+		_, err := client.UpdateAction(ctx, actionName, spec, []string{"spec"})
+		require.Error(t, err)
+		assert.True(t, utils.IsConnectErrorWithCode(err, connect.CodeInvalidArgument))
+	})
+}
+
+func TestActionClient_DeleteAction(t *testing.T) {
+	ctx := testutil.TestContext(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	actionName := &name.Action{ProjectID: "p1", ID: "a1"}
+
+	t.Run("success sends the resolved name", func(t *testing.T) {
+		mock := &mockActionServiceClient{
+			ctrl: ctrl,
+			deleteActionFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.DeleteActionRequest]) (*connect.Response[emptypb.Empty], error) {
+				assert.Equal(t, "projects/p1/actions/a1", req.Msg.Name)
+				return connect.NewResponse(&emptypb.Empty{}), nil
+			},
+		}
+		client := NewActionClient(mock, nil)
+		err := client.DeleteAction(ctx, actionName)
+		require.NoError(t, err)
+	})
+
+	t.Run("error is wrapped preserving connect code", func(t *testing.T) {
+		mock := &mockActionServiceClient{
+			ctrl: ctrl,
+			deleteActionFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.DeleteActionRequest]) (*connect.Response[emptypb.Empty], error) {
+				return nil, connect.NewError(connect.CodePermissionDenied, errors.New("denied"))
+			},
+		}
+		client := NewActionClient(mock, nil)
+		err := client.DeleteAction(ctx, actionName)
+		require.Error(t, err)
+		assert.True(t, utils.IsConnectErrorWithCode(err, connect.CodePermissionDenied))
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/coscene-io/cocli
 go 1.25.0
 
 require (
-	buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260707091417-36de2d80780c.1
-	buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260707091417-36de2d80780c.1
+	buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260709002126-f5ec6f481038.1
+	buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260709002126-f5ec6f481038.1
 	connectrpc.com/connect v1.20.0
 	dario.cat/mergo v1.0.2
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/coscene-io/cocli
 go 1.25.0
 
 require (
-	buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260622125952-8be5fbcdb2b5.1
-	buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260622125952-8be5fbcdb2b5.1
+	buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260707091417-36de2d80780c.1
+	buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260707091417-36de2d80780c.1
 	connectrpc.com/connect v1.20.0
 	dario.cat/mergo v1.0.2
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,12 @@ buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-202405082006
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20240508200655-46a4cf4ba109.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
 buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260622125952-8be5fbcdb2b5.1 h1:FkD9XqiTRajv3APfGS5wifxokp9aknarJahLhCPUVLo=
 buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260622125952-8be5fbcdb2b5.1/go.mod h1:ZnIMRWoJw0ssLl1J81y2N5GQrRWupU7c/KOA8nYh8rg=
+buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260707091417-36de2d80780c.1 h1:rDzcWpSTFhqK0O6aTA5OI6Av72apJAL6ilCBUo4bh9k=
+buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260707091417-36de2d80780c.1/go.mod h1:KpprOuGNQHQw8SOPxmUNRaokhgHmf7jEwE1RJABio1w=
 buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260622125952-8be5fbcdb2b5.1 h1:d7O8CUug2CoMxrcd21ksEcrItZgMY5+gbiXy53w6Uis=
 buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260622125952-8be5fbcdb2b5.1/go.mod h1:ncUQjVNWzogYkhgQ1XinFjWE1h7HuPtKpimyf90abE0=
+buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260707091417-36de2d80780c.1 h1:SYQKB0iw7adpNUUdB4W5+uQPPK7Jq0denOZKYJfVx50=
+buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260707091417-36de2d80780c.1/go.mod h1:ncUQjVNWzogYkhgQ1XinFjWE1h7HuPtKpimyf90abE0=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.11-20230414000709-087bc8072ce4.1 h1:t8f+WWZ5WNrZaP5zrpWD8f1tKU7eelJMbIAT9FRX558=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.11-20230414000709-087bc8072ce4.1/go.mod h1:/t9AeRQQp2iNkiGHDLfHLW3SzNpYpNPGRZ+Ih8+SOUs=
 connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,7 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20240508200655-46a4cf4ba109.1 h1:NXwdBG3BiC6xWH4iG3csbT+JHF9u1jl5ThDhumCnKnk=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20240508200655-46a4cf4ba109.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
-buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260622125952-8be5fbcdb2b5.1 h1:FkD9XqiTRajv3APfGS5wifxokp9aknarJahLhCPUVLo=
-buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260622125952-8be5fbcdb2b5.1/go.mod h1:ZnIMRWoJw0ssLl1J81y2N5GQrRWupU7c/KOA8nYh8rg=
 buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260707091417-36de2d80780c.1 h1:rDzcWpSTFhqK0O6aTA5OI6Av72apJAL6ilCBUo4bh9k=
 buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260707091417-36de2d80780c.1/go.mod h1:KpprOuGNQHQw8SOPxmUNRaokhgHmf7jEwE1RJABio1w=
-buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260622125952-8be5fbcdb2b5.1 h1:d7O8CUug2CoMxrcd21ksEcrItZgMY5+gbiXy53w6Uis=
-buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260622125952-8be5fbcdb2b5.1/go.mod h1:ncUQjVNWzogYkhgQ1XinFjWE1h7HuPtKpimyf90abE0=
 buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260707091417-36de2d80780c.1 h1:SYQKB0iw7adpNUUdB4W5+uQPPK7Jq0denOZKYJfVx50=
 buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260707091417-36de2d80780c.1/go.mod h1:ncUQjVNWzogYkhgQ1XinFjWE1h7HuPtKpimyf90abE0=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.11-20230414000709-087bc8072ce4.1 h1:t8f+WWZ5WNrZaP5zrpWD8f1tKU7eelJMbIAT9FRX558=

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20240508200655-46a4cf4ba109.1 h1:NXwdBG3BiC6xWH4iG3csbT+JHF9u1jl5ThDhumCnKnk=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20240508200655-46a4cf4ba109.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
-buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260707091417-36de2d80780c.1 h1:rDzcWpSTFhqK0O6aTA5OI6Av72apJAL6ilCBUo4bh9k=
-buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260707091417-36de2d80780c.1/go.mod h1:KpprOuGNQHQw8SOPxmUNRaokhgHmf7jEwE1RJABio1w=
-buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260707091417-36de2d80780c.1 h1:SYQKB0iw7adpNUUdB4W5+uQPPK7Jq0denOZKYJfVx50=
-buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260707091417-36de2d80780c.1/go.mod h1:ncUQjVNWzogYkhgQ1XinFjWE1h7HuPtKpimyf90abE0=
+buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260709002126-f5ec6f481038.1 h1:GcMHBF5E8rDLiOjEjGYKciBr/69WT5lJ23vc87lPe8I=
+buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260709002126-f5ec6f481038.1/go.mod h1:9k72p7X+thAVEAa+/B1+SwZAEp19tEBRDq2dJvs+zbw=
+buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260709002126-f5ec6f481038.1 h1:VuRd112Wc13WDGrKHVYnOguGnv3ajn0WCltTlk/9YOc=
+buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260709002126-f5ec6f481038.1/go.mod h1:ncUQjVNWzogYkhgQ1XinFjWE1h7HuPtKpimyf90abE0=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.11-20230414000709-087bc8072ce4.1 h1:t8f+WWZ5WNrZaP5zrpWD8f1tKU7eelJMbIAT9FRX558=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.11-20230414000709-087bc8072ce4.1/go.mod h1:/t9AeRQQp2iNkiGHDLfHLW3SzNpYpNPGRZ+Ih8+SOUs=
 connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=

--- a/internal/printer/printable/action.go
+++ b/internal/printer/printable/action.go
@@ -17,6 +17,7 @@ package printable
 import (
 	"time"
 
+	openv1alpha1commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
 	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
 	openv1alpha1service "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/services"
 	"github.com/coscene-io/cocli/internal/name"
@@ -36,9 +37,29 @@ type Action struct {
 	Delegate []*openv1alpha1resource.Action
 }
 
+type SingleAction struct {
+	Delegate *openv1alpha1resource.Action
+}
+
+type ActionSpec struct {
+	Delegate *openv1alpha1commons.ActionSpec
+}
+
 func NewAction(actions []*openv1alpha1resource.Action) *Action {
 	return &Action{
 		Delegate: actions,
+	}
+}
+
+func NewSingleAction(action *openv1alpha1resource.Action) *SingleAction {
+	return &SingleAction{
+		Delegate: action,
+	}
+}
+
+func NewActionSpec(spec *openv1alpha1commons.ActionSpec) *ActionSpec {
+	return &ActionSpec{
+		Delegate: spec,
 	}
 }
 
@@ -47,6 +68,28 @@ func (p *Action) ToProtoMessage() proto.Message {
 		Actions:   p.Delegate,
 		TotalSize: int64(len(p.Delegate)),
 	}
+}
+
+func (p *SingleAction) ToProtoMessage() proto.Message {
+	return p.Delegate
+}
+
+func (p *ActionSpec) ToProtoMessage() proto.Message {
+	if p.Delegate == nil {
+		return &openv1alpha1commons.ActionSpec{}
+	}
+	return p.Delegate
+}
+
+func (p *SingleAction) ToTable(opts *table.PrintOpts) table.Table {
+	if p.Delegate == nil {
+		return table.ColumnDefs2Table([]table.ColumnDefinitionFull[*openv1alpha1resource.Action]{}, nil, opts)
+	}
+	return NewAction([]*openv1alpha1resource.Action{p.Delegate}).ToTable(opts)
+}
+
+func (p *ActionSpec) ToTable(opts *table.PrintOpts) table.Table {
+	return NewSingleAction(&openv1alpha1resource.Action{Spec: p.Delegate}).ToTable(opts)
 }
 
 func (p *Action) ToTable(opts *table.PrintOpts) table.Table {
@@ -63,6 +106,9 @@ func (p *Action) ToTable(opts *table.PrintOpts) table.Table {
 					return a.Name
 				}
 				actionName, _ := name.NewAction(a.Name)
+				if actionName == nil {
+					return ""
+				}
 				return actionName.ID
 			},
 			TrimSize: actionIdTrimSize,
@@ -71,6 +117,9 @@ func (p *Action) ToTable(opts *table.PrintOpts) table.Table {
 			FieldName: "CATEGORY",
 			FieldValueFunc: func(a *openv1alpha1resource.Action, opts *table.PrintOpts) string {
 				actionName, _ := name.NewAction(a.Name)
+				if actionName == nil {
+					return "custom"
+				}
 				if actionName.IsWftmpl() {
 					return "system"
 				}
@@ -81,6 +130,9 @@ func (p *Action) ToTable(opts *table.PrintOpts) table.Table {
 		{
 			FieldName: "TITLE",
 			FieldValueFunc: func(a *openv1alpha1resource.Action, opts *table.PrintOpts) string {
+				if a.Spec == nil {
+					return ""
+				}
 				return a.Spec.Name
 			},
 			TrimSize: actionTitleTrimSize,
@@ -95,6 +147,9 @@ func (p *Action) ToTable(opts *table.PrintOpts) table.Table {
 		{
 			FieldName: "UPDATE TIME",
 			FieldValueFunc: func(a *openv1alpha1resource.Action, opts *table.PrintOpts) string {
+				if a.UpdateTime == nil {
+					return ""
+				}
 				return a.UpdateTime.AsTime().In(time.Local).Format(time.RFC3339)
 			},
 			TrimSize: actionTimeTrimSize,

--- a/pkg/cmd/action/action_test.go
+++ b/pkg/cmd/action/action_test.go
@@ -43,7 +43,7 @@ func TestActionCommand(t *testing.T) {
 		assert.Equal(t, "action", cmd.Use)
 		assert.NotEmpty(t, cmd.Short)
 
-		expectedSubcommands := []string{"list", "list-run", "run"}
+		expectedSubcommands := []string{"create", "list", "list-run", "logs", "run"}
 
 		for _, expected := range expectedSubcommands {
 			found := false
@@ -69,6 +69,24 @@ func TestActionCommand(t *testing.T) {
 
 		assert.NotNil(t, listCmd.Flag("project"), "Flag --project not found")
 		assert.NotNil(t, listCmd.Flag("output"), "Flag --output not found")
+	})
+
+	t.Run("Create command flags", func(t *testing.T) {
+		cfgPath := setupTestConfig(t)
+		var buf bytes.Buffer
+		io := iostreams.Test(nil, &buf, &buf)
+		cmd := action.NewRootCommand(&cfgPath, io, config.Provide)
+
+		createCmd, _, err := cmd.Find([]string{"create"})
+		require.NoError(t, err)
+
+		assert.NotNil(t, createCmd.Flag("project"), "Flag --project not found")
+		assert.NotNil(t, createCmd.Flag("file"), "Flag --file not found")
+		assert.NotNil(t, createCmd.Flag("dry-run"), "Flag --dry-run not found")
+		assert.NotNil(t, createCmd.Flag("example"), "Flag --example not found")
+		assert.NotNil(t, createCmd.Flag("output"), "Flag --output not found")
+		assert.NotNil(t, createCmd.Flag("image"), "Flag --image not found")
+		assert.NotNil(t, createCmd.Flag("command"), "Flag --command not found")
 	})
 
 	t.Run("Run command flags", func(t *testing.T) {

--- a/pkg/cmd/action/action_test.go
+++ b/pkg/cmd/action/action_test.go
@@ -43,7 +43,7 @@ func TestActionCommand(t *testing.T) {
 		assert.Equal(t, "action", cmd.Use)
 		assert.NotEmpty(t, cmd.Short)
 
-		expectedSubcommands := []string{"create", "list", "list-run", "logs", "run"}
+		expectedSubcommands := []string{"create", "get", "list", "list-run", "logs", "run"}
 
 		for _, expected := range expectedSubcommands {
 			found := false

--- a/pkg/cmd/action/action_test.go
+++ b/pkg/cmd/action/action_test.go
@@ -43,7 +43,7 @@ func TestActionCommand(t *testing.T) {
 		assert.Equal(t, "action", cmd.Use)
 		assert.NotEmpty(t, cmd.Short)
 
-		expectedSubcommands := []string{"create", "get", "list", "list-run", "logs", "run"}
+		expectedSubcommands := []string{"create", "get", "update", "delete", "list", "list-run", "logs", "run"}
 
 		for _, expected := range expectedSubcommands {
 			found := false

--- a/pkg/cmd/action/create.go
+++ b/pkg/cmd/action/create.go
@@ -16,6 +16,7 @@ package action
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -24,6 +25,7 @@ import (
 
 	openv1alpha1commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
 	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"connectrpc.com/connect"
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/printer"
@@ -37,6 +39,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// actionCreateSentinelImage is an obvious placeholder used in the --example
+// skeleton. If it survives unedited into a real create, the action would be
+// junk, so we warn at create-time (see warnActionCreateSentinels).
+const actionCreateSentinelImage = "REPLACE-ME/image:tag"
+
 const actionCreateExample = `# ActionSpec - use with: cocli action create --project <slug> -f spec.yaml
 name: my-action
 description: ""
@@ -45,7 +52,7 @@ jobs:
   - name: job
     depends: []
     container:
-      image: registry.example.com/my-image:tag
+      image: REPLACE-ME/image:tag # <-- replace before creating (see warning)
       command: ["python", "run.py"]
       args: []
       env:
@@ -209,6 +216,10 @@ func NewCreateCommand(cfgPath *string, ioStreams *iostreams.IOStreams, getProvid
 				log.Fatalf("invalid action spec: %v", err)
 			}
 
+			// Warn (non-fatal) if an unedited --example sentinel survived; both
+			// dry-run and real create surface this so agents catch it early.
+			warnActionCreateSentinels(action, ioStreams)
+
 			printFormat := outputFormat
 			if opts.dryRun && !cmd.Flags().Changed("output") {
 				printFormat = "yaml"
@@ -232,6 +243,17 @@ func NewCreateCommand(cfgPath *string, ioStreams *iostreams.IOStreams, getProvid
 			}
 			action, err = pm.ActionCli().CreateAction(cmd.Context(), proj.String(), action)
 			if err != nil {
+				// Quiet exit on Ctrl-C / cancellation (mirror logs.go). No noisy
+				// stack — the user already knows they cancelled.
+				if errors.Is(err, context.Canceled) {
+					os.Exit(1)
+				}
+				// D14: a ResourceExhausted / NO_SUBSCRIPTION failure is almost
+				// always a missing subscription or permission grant, NOT a real
+				// quota limit — retrying will not help, so say so and stop.
+				if isNoSubscriptionError(err) {
+					exitf(ioStreams, "failed to create action: %v\nlikely a missing permission grant, not a quota limit — do not retry", err)
+				}
 				log.Fatalf("failed to create action: %v", err)
 			}
 			if err = p.PrintObj(printable.NewSingleAction(action), ioStreams.Out); err != nil {
@@ -252,12 +274,12 @@ func NewCreateCommand(cfgPath *string, ioStreams *iostreams.IOStreams, getProvid
 	cmd.Flags().StringVar(&opts.jobName, "job-name", "", "single container job name")
 	cmd.Flags().StringVar(&opts.image, "image", "", "container image for inline single-container creation")
 	cmd.Flags().StringVar(&opts.command, "command", "", "container command, split like a shell command line")
-	cmd.Flags().StringArrayVar(&opts.args, "arg", []string{}, "container argument (repeatable)")
+	cmd.Flags().StringArrayVar(&opts.args, "args", []string{}, "container argument (repeatable)")
 	cmd.Flags().StringArrayVar(&opts.env, "env", []string{}, "container environment variable in key=value format (repeatable)")
-	cmd.Flags().StringArrayVar(&opts.params, "param", []string{}, "action parameter default in key=value format (repeatable)")
-	cmd.Flags().StringVar(&opts.quotaProfile, "quota-profile", "", "quota profile: small|medium|large|xlarge")
-	cmd.Flags().StringVar(&opts.cpuQuota, "cpu-quota", "", "raw CPU quota enum, e.g. CPU_QUOTA_1C")
-	cmd.Flags().StringVar(&opts.memoryQuota, "memory-quota", "", "raw memory quota enum, e.g. MEMORY_QUOTA_2G")
+	cmd.Flags().StringArrayVarP(&opts.params, "param", "P", []string{}, "action parameter default in key=value format (repeatable)")
+	cmd.Flags().StringVar(&opts.quotaProfile, "quota", "", "quota profile: small|medium|large|xlarge")
+	cmd.Flags().StringVar(&opts.cpuQuota, "cpu-quota", "", "raw CPU quota enum override, e.g. CPU_QUOTA_1C")
+	cmd.Flags().StringVar(&opts.memoryQuota, "memory-quota", "", "raw memory quota enum override, e.g. MEMORY_QUOTA_2G")
 
 	return cmd
 }
@@ -336,11 +358,11 @@ func applyActionCreateOverrides(spec *actionCreateSpec, opts *actionCreateOption
 			spec.Parameters[k] = v
 		}
 	}
-	if changed("quota-profile") || changed("cpu-quota") || changed("memory-quota") {
+	if changed("quota") || changed("cpu-quota") || changed("memory-quota") {
 		if spec.Quota == nil {
 			spec.Quota = &actionCreateQuota{}
 		}
-		if changed("quota-profile") {
+		if changed("quota") {
 			spec.Quota.Profile = opts.quotaProfile
 		}
 		if changed("cpu-quota") {
@@ -351,7 +373,7 @@ func applyActionCreateOverrides(spec *actionCreateSpec, opts *actionCreateOption
 		}
 	}
 
-	if !changed("job-name") && !changed("image") && !changed("command") && !changed("arg") && !changed("env") {
+	if !changed("job-name") && !changed("image") && !changed("command") && !changed("args") && !changed("env") {
 		return nil
 	}
 	job, err := singleActionCreateJob(spec)
@@ -361,7 +383,7 @@ func applyActionCreateOverrides(spec *actionCreateSpec, opts *actionCreateOption
 	if changed("job-name") {
 		job.Name = opts.jobName
 	}
-	if changed("image") || changed("command") || changed("arg") || changed("env") {
+	if changed("image") || changed("command") || changed("args") || changed("env") {
 		if job.Container == nil {
 			job.Container = &actionCreateContainerSpec{}
 		}
@@ -377,7 +399,7 @@ func applyActionCreateOverrides(spec *actionCreateSpec, opts *actionCreateOption
 		}
 		job.Container.Command = words
 	}
-	if changed("arg") {
+	if changed("args") {
 		job.Container.Args = append([]string(nil), opts.args...)
 	}
 	if changed("env") {
@@ -651,6 +673,43 @@ func validateActionForCreate(action *openv1alpha1resource.Action) error {
 		return errors.New(strings.Join(msgs, "; "))
 	}
 	return nil
+}
+
+// isNoSubscriptionError reports whether a CreateAction failure is the D14
+// "no subscription / missing permission grant" case rather than a genuine
+// transient quota limit. The backend signals this with a ResourceExhausted
+// connect code and/or a NO_SUBSCRIPTION detail; either way, retrying will not
+// help. Mirrors the connect-code inspection style in logs.go (errors.As +
+// connErr.Code()).
+func isNoSubscriptionError(err error) bool {
+	var connErr *connect.Error
+	if !errors.As(err, &connErr) {
+		return false
+	}
+	if strings.Contains(strings.ToUpper(err.Error()), "NO_SUBSCRIPTION") {
+		return true
+	}
+	return connErr.Code() == connect.CodeResourceExhausted
+}
+
+// warnActionCreateSentinels warns to stderr when an unedited --example sentinel
+// (e.g. the placeholder image) survives into the spec. It does not block: the
+// server-side validation is authoritative, but a surviving sentinel almost
+// always means the user forgot to fill in the skeleton and would otherwise
+// create a junk action.
+func warnActionCreateSentinels(action *openv1alpha1resource.Action, io *iostreams.IOStreams) {
+	if action == nil || action.GetSpec() == nil {
+		return
+	}
+	for _, job := range action.GetSpec().GetJobs() {
+		container := job.GetContainer()
+		if container == nil {
+			continue
+		}
+		if container.GetImage() == actionCreateSentinelImage {
+			io.Eprintf("warning: job %q still uses the example sentinel image %q — edit the spec before creating a real action\n", job.GetName(), actionCreateSentinelImage)
+		}
+	}
 }
 
 func parseActionCreateKeyValues(items []string, flagName string) (map[string]string, error) {

--- a/pkg/cmd/action/create.go
+++ b/pkg/cmd/action/create.go
@@ -49,7 +49,7 @@ name: my-action
 description: ""
 labels: []
 jobs:
-  - name: job
+  - name: main
     depends: []
     container:
       image: REPLACE-ME/image:tag # <-- replace before creating (see warning)
@@ -77,11 +77,8 @@ type actionCreateOptions struct {
 	example      bool
 	name         string
 	description  string
-	labels       []string
-	jobName      string
 	image        string
 	command      string
-	args         []string
 	env          []string
 	params       []string
 	quotaProfile string
@@ -266,11 +263,8 @@ func NewCreateCommand(cfgPath *string, ioStreams *iostreams.IOStreams, getProvid
 
 	cmd.Flags().StringVar(&opts.name, "name", "", "action name for inline single-container creation")
 	cmd.Flags().StringVar(&opts.description, "description", "", "action description for inline single-container creation")
-	cmd.Flags().StringArrayVar(&opts.labels, "label", []string{}, "action label (repeatable)")
-	cmd.Flags().StringVar(&opts.jobName, "job-name", "", "single container job name")
 	cmd.Flags().StringVar(&opts.image, "image", "", "container image for inline single-container creation")
-	cmd.Flags().StringVar(&opts.command, "command", "", "container command, split like a shell command line")
-	cmd.Flags().StringArrayVar(&opts.args, "args", []string{}, "container argument (repeatable)")
+	cmd.Flags().StringVar(&opts.command, "command", "", "container command line (shell-split, quote-aware; e.g. 'python train.py --epochs 10')")
 	cmd.Flags().StringArrayVar(&opts.env, "env", []string{}, "container environment variable in key=value format (repeatable)")
 	cmd.Flags().StringArrayVarP(&opts.params, "param", "P", []string{}, "action parameter default in key=value format (repeatable)")
 	cmd.Flags().StringVar(&opts.quotaProfile, "quota", "", "quota profile: small|medium|large|xlarge")
@@ -337,9 +331,6 @@ func applyActionCreateOverrides(spec *actionCreateSpec, opts *actionCreateOption
 	if changed("description") {
 		spec.Description = opts.description
 	}
-	if changed("label") {
-		spec.Labels = append([]string(nil), opts.labels...)
-	}
 	if changed("param") {
 		params, err := parseActionCreateKeyValues(opts.params, "param")
 		if err != nil {
@@ -359,17 +350,14 @@ func applyActionCreateOverrides(spec *actionCreateSpec, opts *actionCreateOption
 		spec.Quota.Profile = opts.quotaProfile
 	}
 
-	if !changed("job-name") && !changed("image") && !changed("command") && !changed("args") && !changed("env") {
+	if !changed("image") && !changed("command") && !changed("env") {
 		return nil
 	}
 	job, err := singleActionCreateJob(spec)
 	if err != nil {
 		return err
 	}
-	if changed("job-name") {
-		job.Name = opts.jobName
-	}
-	if changed("image") || changed("command") || changed("args") || changed("env") {
+	if changed("image") || changed("command") || changed("env") {
 		if job.Container == nil {
 			job.Container = &actionCreateContainerSpec{}
 		}
@@ -384,9 +372,6 @@ func applyActionCreateOverrides(spec *actionCreateSpec, opts *actionCreateOption
 			return errors.Wrap(err, "parse command")
 		}
 		job.Container.Command = words
-	}
-	if changed("args") {
-		job.Container.Args = append([]string(nil), opts.args...)
 	}
 	if changed("env") {
 		env, err := parseActionCreateKeyValues(opts.env, "env")
@@ -406,7 +391,7 @@ func applyActionCreateOverrides(spec *actionCreateSpec, opts *actionCreateOption
 func singleActionCreateJob(spec *actionCreateSpec) (*actionCreateJobSpec, error) {
 	switch len(spec.Jobs) {
 	case 0:
-		spec.Jobs = []actionCreateJobSpec{{Name: "job"}}
+		spec.Jobs = []actionCreateJobSpec{{Name: "main"}}
 	case 1:
 	default:
 		return nil, errors.New("inline job flags can only be used with zero or one job")
@@ -598,7 +583,7 @@ func validateActionForCreate(action *openv1alpha1resource.Action) error {
 		msgs = append(msgs, "jobs cannot be empty")
 	}
 	if len(spec.Jobs) == 1 && spec.Jobs[0].Name == "" {
-		spec.Jobs[0].Name = "job"
+		spec.Jobs[0].Name = "main"
 	}
 	for _, job := range spec.Jobs {
 		if job.Name == "" {

--- a/pkg/cmd/action/create.go
+++ b/pkg/cmd/action/create.go
@@ -1,0 +1,796 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	openv1alpha1commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/internal/printer"
+	"github.com/coscene-io/cocli/internal/printer/printable"
+	"github.com/coscene-io/cocli/internal/printer/table"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/types/known/structpb"
+	"gopkg.in/yaml.v3"
+)
+
+const actionCreateExample = `# ActionSpec - use with: cocli action create --project <slug> -f spec.yaml
+name: my-action
+description: ""
+labels: []
+jobs:
+  - name: job
+    depends: []
+    container:
+      image: registry.example.com/my-image:tag
+      command: ["python", "run.py"]
+      args: []
+      env:
+        COS_KEY: "value"
+parameters:
+  X: "default"
+quota:
+  profile: small # small|medium|large|xlarge. Or use raw cpu/memory enum fields.
+output_options:
+  save_mode: APPEND
+`
+
+var (
+	actionCreateJobNameRe = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+	actionCreateEnvRe     = regexp.MustCompile(`[-._a-zA-Z][-._a-zA-Z0-9]*`)
+	actionCreateParamRe   = regexp.MustCompile(`\{\{\s*([^{}]+?)\s*\}\}`)
+)
+
+type actionCreateOptions struct {
+	filePath     string
+	dryRun       bool
+	example      bool
+	name         string
+	description  string
+	labels       []string
+	jobName      string
+	image        string
+	command      string
+	args         []string
+	env          []string
+	params       []string
+	quotaProfile string
+	cpuQuota     string
+	memoryQuota  string
+}
+
+type actionCreateSpec struct {
+	Name               string                      `yaml:"name"`
+	Description        string                      `yaml:"description"`
+	Labels             []string                    `yaml:"labels"`
+	Jobs               []actionCreateJobSpec       `yaml:"jobs"`
+	Parameters         map[string]string           `yaml:"parameters"`
+	MountOptions       *actionCreateMountOptions   `yaml:"mount_options"`
+	MountOptionsJSON   *actionCreateMountOptions   `yaml:"mountOptions"`
+	StorageOptions     *actionCreateStorageOptions `yaml:"storage_options"`
+	StorageOptionsJSON *actionCreateStorageOptions `yaml:"storageOptions"`
+	Quota              *actionCreateQuota          `yaml:"quota"`
+	OutputOptions      *actionCreateOutputOptions  `yaml:"output_options"`
+	OutputOptionsJSON  *actionCreateOutputOptions  `yaml:"outputOptions"`
+}
+
+type actionCreateSpecWrapper struct {
+	Spec *actionCreateSpec `yaml:"spec"`
+}
+
+type actionCreateJobSpec struct {
+	Name      string                     `yaml:"name"`
+	Depends   []string                   `yaml:"depends"`
+	Container *actionCreateContainerSpec `yaml:"container"`
+	HTTP      *actionCreateHTTPSpec      `yaml:"http"`
+}
+
+type actionCreateContainerSpec struct {
+	Image   string            `yaml:"image"`
+	Command actionCreateWords `yaml:"command"`
+	Args    actionCreateWords `yaml:"args"`
+	Env     map[string]string `yaml:"env"`
+}
+
+type actionCreateHTTPSpec struct {
+	Method  string                 `yaml:"method"`
+	URL     string                 `yaml:"url"`
+	Headers map[string]string      `yaml:"headers"`
+	Body    map[string]interface{} `yaml:"body"`
+	Timeout int32                  `yaml:"timeout"`
+}
+
+type actionCreateQuota struct {
+	Profile string `yaml:"profile"`
+	CPU     string `yaml:"cpu"`
+	Memory  string `yaml:"memory"`
+}
+
+type actionCreateMountOptions struct {
+	ReadWrite                 bool  `yaml:"read_write"`
+	ReadWriteJSON             bool  `yaml:"readWrite"`
+	ContainerStorageBytes     int64 `yaml:"container_storage_bytes"`
+	ContainerStorageBytesJSON int64 `yaml:"containerStorageBytes"`
+}
+
+type actionCreateStorageOptions struct {
+	ContainerStorageBytes     int64                          `yaml:"container_storage_bytes"`
+	ContainerStorageBytesJSON int64                          `yaml:"containerStorageBytes"`
+	SSDOptions                *actionCreateStorageSSDOptions `yaml:"ssd_options"`
+	SSDOptionsJSON            *actionCreateStorageSSDOptions `yaml:"ssdOptions"`
+}
+
+type actionCreateStorageSSDOptions struct {
+	UseSSD        bool   `yaml:"use_ssd"`
+	UseSSDJSON    bool   `yaml:"useSsd"`
+	MountPath     string `yaml:"mount_path"`
+	MountPathJSON string `yaml:"mountPath"`
+}
+
+type actionCreateOutputOptions struct {
+	SaveMode     string `yaml:"save_mode"`
+	SaveModeJSON string `yaml:"saveMode"`
+}
+
+type actionCreateWords []string
+
+func (w *actionCreateWords) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		words, err := splitActionCreateWords(value.Value)
+		if err != nil {
+			return err
+		}
+		*w = words
+		return nil
+	case yaml.SequenceNode:
+		words := make([]string, 0, len(value.Content))
+		for _, item := range value.Content {
+			if item.Kind != yaml.ScalarNode {
+				return fmt.Errorf("command and args entries must be strings")
+			}
+			words = append(words, item.Value)
+		}
+		*w = words
+		return nil
+	case 0:
+		return nil
+	default:
+		return fmt.Errorf("command and args must be a string or string array")
+	}
+}
+
+func NewCreateCommand(cfgPath *string, ioStreams *iostreams.IOStreams, getProvider func(string) config.Provider) *cobra.Command {
+	var (
+		opts         actionCreateOptions
+		projectSlug  string
+		outputFormat string
+	)
+
+	cmd := &cobra.Command{
+		Use:                   "create --project <working-project-slug> (-f spec.yaml|json | --name <name> --image <image>)",
+		Short:                 "Create an action.",
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			if opts.example {
+				ioStreams.Printf("%s", actionCreateExample)
+				return
+			}
+
+			action, err := buildActionForCreate(&opts, cmd, ioStreams.In)
+			if err != nil {
+				log.Fatalf("invalid action spec: %v", err)
+			}
+			if err = validateActionForCreate(action); err != nil {
+				log.Fatalf("invalid action spec: %v", err)
+			}
+
+			printFormat := outputFormat
+			if opts.dryRun && !cmd.Flags().Changed("output") {
+				printFormat = "yaml"
+			}
+
+			p, err := printer.Printer(printFormat, &printer.Options{TableOpts: &table.PrintOpts{Verbose: true}})
+			if err != nil {
+				log.Fatal(err)
+			}
+			if opts.dryRun {
+				if err = p.PrintObj(printable.NewActionSpec(action.GetSpec()), ioStreams.Out); err != nil {
+					log.Fatalf("failed to print action spec: %v", err)
+				}
+				return
+			}
+
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
+			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
+			if err != nil {
+				log.Fatalf("unable to get project name: %v", err)
+			}
+			action, err = pm.ActionCli().CreateAction(cmd.Context(), proj.String(), action)
+			if err != nil {
+				log.Fatalf("failed to create action: %v", err)
+			}
+			if err = p.PrintObj(printable.NewSingleAction(action), ioStreams.Out); err != nil {
+				log.Fatalf("failed to print action: %v", err)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&projectSlug, "project", "p", "", "the slug of the working project")
+	cmd.Flags().StringVarP(&opts.filePath, "file", "f", "", "action spec YAML/JSON file (`-` for stdin)")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "validate and print the lowered action without creating it")
+	cmd.Flags().BoolVar(&opts.example, "example", false, "print an example action spec")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "output format (table|json|yaml)")
+
+	cmd.Flags().StringVar(&opts.name, "name", "", "action name for inline single-container creation")
+	cmd.Flags().StringVar(&opts.description, "description", "", "action description for inline single-container creation")
+	cmd.Flags().StringArrayVar(&opts.labels, "label", []string{}, "action label (repeatable)")
+	cmd.Flags().StringVar(&opts.jobName, "job-name", "", "single container job name")
+	cmd.Flags().StringVar(&opts.image, "image", "", "container image for inline single-container creation")
+	cmd.Flags().StringVar(&opts.command, "command", "", "container command, split like a shell command line")
+	cmd.Flags().StringArrayVar(&opts.args, "arg", []string{}, "container argument (repeatable)")
+	cmd.Flags().StringArrayVar(&opts.env, "env", []string{}, "container environment variable in key=value format (repeatable)")
+	cmd.Flags().StringArrayVar(&opts.params, "param", []string{}, "action parameter default in key=value format (repeatable)")
+	cmd.Flags().StringVar(&opts.quotaProfile, "quota-profile", "", "quota profile: small|medium|large|xlarge")
+	cmd.Flags().StringVar(&opts.cpuQuota, "cpu-quota", "", "raw CPU quota enum, e.g. CPU_QUOTA_1C")
+	cmd.Flags().StringVar(&opts.memoryQuota, "memory-quota", "", "raw memory quota enum, e.g. MEMORY_QUOTA_2G")
+
+	return cmd
+}
+
+func buildActionForCreate(opts *actionCreateOptions, cmd *cobra.Command, stdin io.Reader) (*openv1alpha1resource.Action, error) {
+	spec := &actionCreateSpec{}
+	if opts.filePath != "" {
+		loaded, err := loadActionCreateSpec(opts.filePath, stdin)
+		if err != nil {
+			return nil, err
+		}
+		spec = loaded
+	}
+
+	if err := applyActionCreateOverrides(spec, opts, func(name string) bool { return cmd.Flags().Changed(name) }); err != nil {
+		return nil, err
+	}
+	return lowerActionCreateSpec(spec)
+}
+
+func loadActionCreateSpec(path string, stdin io.Reader) (*actionCreateSpec, error) {
+	var data []byte
+	var err error
+	if path == "-" {
+		if stdin == nil {
+			return nil, errors.New("stdin is not available")
+		}
+		data, err = io.ReadAll(stdin)
+	} else {
+		data, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "read action spec")
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, errors.New("action spec is empty")
+	}
+
+	var spec actionCreateSpec
+	if err = decodeActionCreateYAML(data, &spec); err != nil {
+		var wrapper actionCreateSpecWrapper
+		if wrapperErr := decodeActionCreateYAML(data, &wrapper); wrapperErr != nil || wrapper.Spec == nil {
+			return nil, errors.Wrap(err, "parse action spec")
+		}
+		spec = *wrapper.Spec
+	}
+	normalizeActionCreateAliases(&spec)
+	return &spec, nil
+}
+
+func decodeActionCreateYAML(data []byte, out interface{}) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	return dec.Decode(out)
+}
+
+func applyActionCreateOverrides(spec *actionCreateSpec, opts *actionCreateOptions, changed func(string) bool) error {
+	if changed("name") {
+		spec.Name = opts.name
+	}
+	if changed("description") {
+		spec.Description = opts.description
+	}
+	if changed("label") {
+		spec.Labels = append([]string(nil), opts.labels...)
+	}
+	if changed("param") {
+		params, err := parseActionCreateKeyValues(opts.params, "param")
+		if err != nil {
+			return err
+		}
+		if spec.Parameters == nil {
+			spec.Parameters = map[string]string{}
+		}
+		for k, v := range params {
+			spec.Parameters[k] = v
+		}
+	}
+	if changed("quota-profile") || changed("cpu-quota") || changed("memory-quota") {
+		if spec.Quota == nil {
+			spec.Quota = &actionCreateQuota{}
+		}
+		if changed("quota-profile") {
+			spec.Quota.Profile = opts.quotaProfile
+		}
+		if changed("cpu-quota") {
+			spec.Quota.CPU = opts.cpuQuota
+		}
+		if changed("memory-quota") {
+			spec.Quota.Memory = opts.memoryQuota
+		}
+	}
+
+	if !changed("job-name") && !changed("image") && !changed("command") && !changed("arg") && !changed("env") {
+		return nil
+	}
+	job, err := singleActionCreateJob(spec)
+	if err != nil {
+		return err
+	}
+	if changed("job-name") {
+		job.Name = opts.jobName
+	}
+	if changed("image") || changed("command") || changed("arg") || changed("env") {
+		if job.Container == nil {
+			job.Container = &actionCreateContainerSpec{}
+		}
+		job.HTTP = nil
+	}
+	if changed("image") {
+		job.Container.Image = opts.image
+	}
+	if changed("command") {
+		words, err := splitActionCreateWords(opts.command)
+		if err != nil {
+			return errors.Wrap(err, "parse command")
+		}
+		job.Container.Command = words
+	}
+	if changed("arg") {
+		job.Container.Args = append([]string(nil), opts.args...)
+	}
+	if changed("env") {
+		env, err := parseActionCreateKeyValues(opts.env, "env")
+		if err != nil {
+			return err
+		}
+		if job.Container.Env == nil {
+			job.Container.Env = map[string]string{}
+		}
+		for k, v := range env {
+			job.Container.Env[k] = v
+		}
+	}
+	return nil
+}
+
+func singleActionCreateJob(spec *actionCreateSpec) (*actionCreateJobSpec, error) {
+	switch len(spec.Jobs) {
+	case 0:
+		spec.Jobs = []actionCreateJobSpec{{Name: "job"}}
+	case 1:
+	default:
+		return nil, errors.New("inline job flags can only be used with zero or one job")
+	}
+	return &spec.Jobs[0], nil
+}
+
+func normalizeActionCreateAliases(spec *actionCreateSpec) {
+	if spec.MountOptions == nil {
+		spec.MountOptions = spec.MountOptionsJSON
+	}
+	if spec.StorageOptions == nil {
+		spec.StorageOptions = spec.StorageOptionsJSON
+	}
+	if spec.OutputOptions == nil {
+		spec.OutputOptions = spec.OutputOptionsJSON
+	}
+	if spec.MountOptions != nil {
+		spec.MountOptions.normalizeAliases()
+	}
+	if spec.StorageOptions != nil {
+		spec.StorageOptions.normalizeAliases()
+	}
+	if spec.OutputOptions != nil {
+		spec.OutputOptions.normalizeAliases()
+	}
+}
+
+func (opts *actionCreateMountOptions) normalizeAliases() {
+	if opts.ReadWriteJSON {
+		opts.ReadWrite = true
+	}
+	if opts.ContainerStorageBytes == 0 {
+		opts.ContainerStorageBytes = opts.ContainerStorageBytesJSON
+	}
+}
+
+func (opts *actionCreateStorageOptions) normalizeAliases() {
+	if opts.ContainerStorageBytes == 0 {
+		opts.ContainerStorageBytes = opts.ContainerStorageBytesJSON
+	}
+	if opts.SSDOptions == nil {
+		opts.SSDOptions = opts.SSDOptionsJSON
+	}
+	if opts.SSDOptions != nil {
+		opts.SSDOptions.normalizeAliases()
+	}
+}
+
+func (opts *actionCreateStorageSSDOptions) normalizeAliases() {
+	if opts.UseSSDJSON {
+		opts.UseSSD = true
+	}
+	if opts.MountPath == "" {
+		opts.MountPath = opts.MountPathJSON
+	}
+}
+
+func (opts *actionCreateOutputOptions) normalizeAliases() {
+	if opts.SaveMode == "" {
+		opts.SaveMode = opts.SaveModeJSON
+	}
+}
+
+func lowerActionCreateSpec(spec *actionCreateSpec) (*openv1alpha1resource.Action, error) {
+	normalizeActionCreateAliases(spec)
+
+	actionSpec := &openv1alpha1commons.ActionSpec{
+		Name:        spec.Name,
+		Description: spec.Description,
+		Labels:      append([]string(nil), spec.Labels...),
+		Parameters:  copyStringMap(spec.Parameters),
+	}
+
+	for i := range spec.Jobs {
+		job, err := lowerActionCreateJob(&spec.Jobs[i])
+		if err != nil {
+			return nil, err
+		}
+		actionSpec.Jobs = append(actionSpec.Jobs, job)
+	}
+
+	if spec.MountOptions != nil {
+		actionSpec.MountOptions = &openv1alpha1commons.MountOptions{
+			ReadWrite:             spec.MountOptions.ReadWrite,
+			ContainerStorageBytes: spec.MountOptions.ContainerStorageBytes,
+		}
+	}
+	if spec.StorageOptions != nil {
+		actionSpec.StorageOptions = &openv1alpha1commons.StorageOptions{
+			ContainerStorageBytes: spec.StorageOptions.ContainerStorageBytes,
+		}
+		if spec.StorageOptions.SSDOptions != nil {
+			actionSpec.StorageOptions.SsdOptions = &openv1alpha1commons.StorageOptions_SSDOptions{
+				UseSsd:    spec.StorageOptions.SSDOptions.UseSSD,
+				MountPath: spec.StorageOptions.SSDOptions.MountPath,
+			}
+		}
+	}
+	if spec.Quota != nil {
+		quota, err := lowerActionCreateQuota(spec.Quota)
+		if err != nil {
+			return nil, err
+		}
+		actionSpec.Quota = quota
+	}
+	if spec.OutputOptions != nil {
+		saveMode, err := parseActionCreateSaveMode(spec.OutputOptions.SaveMode)
+		if err != nil {
+			return nil, err
+		}
+		actionSpec.OutputOptions = &openv1alpha1commons.OutputOptions{SaveMode: saveMode}
+	}
+
+	return &openv1alpha1resource.Action{Spec: actionSpec}, nil
+}
+
+func lowerActionCreateJob(job *actionCreateJobSpec) (*openv1alpha1commons.JobSpec, error) {
+	if job.Container != nil && job.HTTP != nil {
+		return nil, fmt.Errorf("job %q must set only one of container or http", job.Name)
+	}
+	out := &openv1alpha1commons.JobSpec{
+		Name:    job.Name,
+		Depends: append([]string(nil), job.Depends...),
+	}
+	if job.Container != nil {
+		out.JobKind = &openv1alpha1commons.JobSpec_Container{
+			Container: &openv1alpha1commons.ContainerJobSpec{
+				Image:   job.Container.Image,
+				Command: append([]string(nil), job.Container.Command...),
+				Args:    append([]string(nil), job.Container.Args...),
+				Env:     copyStringMap(job.Container.Env),
+			},
+		}
+	}
+	if job.HTTP != nil {
+		method, err := parseActionCreateHTTPMethod(job.HTTP.Method)
+		if err != nil {
+			return nil, err
+		}
+		httpSpec := &openv1alpha1commons.HttpJobSpec{
+			Method:  method,
+			Url:     job.HTTP.URL,
+			Headers: copyStringMap(job.HTTP.Headers),
+			Timeout: job.HTTP.Timeout,
+		}
+		if job.HTTP.Body != nil {
+			body, err := structpb.NewStruct(normalizeActionCreateStruct(job.HTTP.Body))
+			if err != nil {
+				return nil, errors.Wrapf(err, "invalid http body for job %q", job.Name)
+			}
+			httpSpec.Body = body
+		}
+		out.JobKind = &openv1alpha1commons.JobSpec_Http{
+			Http: httpSpec,
+		}
+	}
+	return out, nil
+}
+
+func lowerActionCreateQuota(quota *actionCreateQuota) (*openv1alpha1commons.Quota, error) {
+	if quota.Profile != "" && (quota.CPU != "" || quota.Memory != "") {
+		return nil, errors.New("quota.profile cannot be combined with quota.cpu or quota.memory")
+	}
+	if quota.Profile != "" {
+		switch strings.ToLower(quota.Profile) {
+		case "small":
+			return &openv1alpha1commons.Quota{Cpu: openv1alpha1commons.Quota_CPU_QUOTA_1C, Memory: openv1alpha1commons.Quota_MEMORY_QUOTA_2G}, nil
+		case "medium":
+			return &openv1alpha1commons.Quota{Cpu: openv1alpha1commons.Quota_CPU_QUOTA_2C, Memory: openv1alpha1commons.Quota_MEMORY_QUOTA_4G}, nil
+		case "large":
+			return &openv1alpha1commons.Quota{Cpu: openv1alpha1commons.Quota_CPU_QUOTA_4C, Memory: openv1alpha1commons.Quota_MEMORY_QUOTA_8G}, nil
+		case "xlarge":
+			return &openv1alpha1commons.Quota{Cpu: openv1alpha1commons.Quota_CPU_QUOTA_8C, Memory: openv1alpha1commons.Quota_MEMORY_QUOTA_16G}, nil
+		default:
+			return nil, fmt.Errorf("unknown quota profile %q", quota.Profile)
+		}
+	}
+
+	out := &openv1alpha1commons.Quota{}
+	var err error
+	if quota.CPU != "" {
+		out.Cpu, err = parseActionCreateCPUQuota(quota.CPU)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if quota.Memory != "" {
+		out.Memory, err = parseActionCreateMemoryQuota(quota.Memory)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func validateActionForCreate(action *openv1alpha1resource.Action) error {
+	if action == nil || action.Spec == nil {
+		return errors.New("action spec must not be empty")
+	}
+	spec := action.Spec
+	var msgs []string
+	if spec.Name == "" {
+		msgs = append(msgs, "name cannot be empty")
+	}
+	if len(spec.Jobs) == 0 {
+		msgs = append(msgs, "jobs cannot be empty")
+	}
+	if len(spec.Jobs) == 1 && spec.Jobs[0].Name == "" {
+		spec.Jobs[0].Name = "job"
+	}
+	for _, job := range spec.Jobs {
+		if job.Name == "" {
+			msgs = append(msgs, "job name cannot be empty")
+		}
+		if !actionCreateJobNameRe.MatchString(job.Name) {
+			msgs = append(msgs, fmt.Sprintf("job name %q must match %s", job.Name, actionCreateJobNameRe.String()))
+		}
+		if job.JobKind == nil {
+			msgs = append(msgs, fmt.Sprintf("job %q must define container or http", job.Name))
+		}
+		containerJob, ok := job.JobKind.(*openv1alpha1commons.JobSpec_Container)
+		if !ok || containerJob.Container == nil {
+			continue
+		}
+		for env := range containerJob.Container.Env {
+			if !actionCreateEnvRe.MatchString(env) {
+				msgs = append(msgs, fmt.Sprintf("env name %q must match %s", env, actionCreateEnvRe.String()))
+			}
+		}
+		for _, cmd := range containerJob.Container.Command {
+			for _, match := range actionCreateParamRe.FindAllStringSubmatch(cmd, -1) {
+				param := strings.TrimSpace(match[1])
+				if !strings.HasPrefix(param, "parameters.") {
+					msgs = append(msgs, fmt.Sprintf("parameter reference %q must start with parameters.", param))
+					continue
+				}
+				param = strings.TrimPrefix(param, "parameters.")
+				if param == "" {
+					msgs = append(msgs, "parameter reference cannot be empty")
+					continue
+				}
+				if _, ok := spec.Parameters[param]; !ok {
+					msgs = append(msgs, fmt.Sprintf("parameter %q is referenced but not defined", param))
+				}
+			}
+		}
+	}
+	if len(msgs) > 0 {
+		return errors.New(strings.Join(msgs, "; "))
+	}
+	return nil
+}
+
+func parseActionCreateKeyValues(items []string, flagName string) (map[string]string, error) {
+	values := map[string]string{}
+	for _, item := range items {
+		key, value, ok := strings.Cut(item, "=")
+		if !ok || key == "" {
+			return nil, fmt.Errorf("--%s expects key=value, got %q", flagName, item)
+		}
+		values[key] = value
+	}
+	return values, nil
+}
+
+func parseActionCreateCPUQuota(value string) (openv1alpha1commons.Quota_CPUQuota, error) {
+	key := strings.ToUpper(strings.TrimSpace(value))
+	if !strings.HasPrefix(key, "CPU_QUOTA_") {
+		key = "CPU_QUOTA_" + key
+	}
+	if v, ok := openv1alpha1commons.Quota_CPUQuota_value[key]; ok {
+		return openv1alpha1commons.Quota_CPUQuota(v), nil
+	}
+	return openv1alpha1commons.Quota_CPU_QUOTA_UNSPECIFIED, fmt.Errorf("unknown CPU quota %q", value)
+}
+
+func parseActionCreateMemoryQuota(value string) (openv1alpha1commons.Quota_MemoryQuota, error) {
+	key := strings.ToUpper(strings.TrimSpace(value))
+	if !strings.HasPrefix(key, "MEMORY_QUOTA_") {
+		key = "MEMORY_QUOTA_" + key
+	}
+	if v, ok := openv1alpha1commons.Quota_MemoryQuota_value[key]; ok {
+		return openv1alpha1commons.Quota_MemoryQuota(v), nil
+	}
+	return openv1alpha1commons.Quota_MEMORY_QUOTA_UNSPECIFIED, fmt.Errorf("unknown memory quota %q", value)
+}
+
+func parseActionCreateHTTPMethod(value string) (openv1alpha1commons.HttpJobSpec_HttpMethod, error) {
+	if value == "" {
+		return openv1alpha1commons.HttpJobSpec_HTTP_METHOD_UNSPECIFIED, nil
+	}
+	key := strings.ToUpper(strings.TrimSpace(value))
+	if v, ok := openv1alpha1commons.HttpJobSpec_HttpMethod_value[key]; ok {
+		return openv1alpha1commons.HttpJobSpec_HttpMethod(v), nil
+	}
+	return openv1alpha1commons.HttpJobSpec_HTTP_METHOD_UNSPECIFIED, fmt.Errorf("unknown HTTP method %q", value)
+}
+
+func parseActionCreateSaveMode(value string) (openv1alpha1commons.OutputOptions_SaveMode, error) {
+	if value == "" {
+		return openv1alpha1commons.OutputOptions_SAVE_MODE_UNSPECIFIED, nil
+	}
+	key := strings.ToUpper(strings.TrimSpace(value))
+	if v, ok := openv1alpha1commons.OutputOptions_SaveMode_value[key]; ok {
+		return openv1alpha1commons.OutputOptions_SaveMode(v), nil
+	}
+	return openv1alpha1commons.OutputOptions_SAVE_MODE_UNSPECIFIED, fmt.Errorf("unknown output save mode %q", value)
+}
+
+func splitActionCreateWords(input string) ([]string, error) {
+	var words []string
+	var current strings.Builder
+	var quote rune
+	escaped := false
+
+	for _, r := range input {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if r == '\\' {
+			escaped = true
+			continue
+		}
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+				continue
+			}
+			current.WriteRune(r)
+			continue
+		}
+		if r == '\'' || r == '"' {
+			quote = r
+			continue
+		}
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			if current.Len() > 0 {
+				words = append(words, current.String())
+				current.Reset()
+			}
+			continue
+		}
+		current.WriteRune(r)
+	}
+	if escaped {
+		current.WriteRune('\\')
+	}
+	if quote != 0 {
+		return nil, errors.New("unterminated quote")
+	}
+	if current.Len() > 0 {
+		words = append(words, current.String())
+	}
+	return words, nil
+}
+
+func normalizeActionCreateStruct(in map[string]interface{}) map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = normalizeActionCreateValue(v)
+	}
+	return out
+}
+
+func normalizeActionCreateValue(v interface{}) interface{} {
+	switch typed := v.(type) {
+	case map[string]interface{}:
+		return normalizeActionCreateStruct(typed)
+	case []interface{}:
+		out := make([]interface{}, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, normalizeActionCreateValue(item))
+		}
+		return out
+	default:
+		return typed
+	}
+}
+
+func copyStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/cmd/action/create.go
+++ b/pkg/cmd/action/create.go
@@ -60,7 +60,7 @@ jobs:
 parameters:
   X: "default"
 quota:
-  profile: small # small|medium|large|xlarge. Or use raw cpu/memory enum fields.
+  profile: small # small|medium|large|xlarge
 output_options:
   save_mode: APPEND
 `
@@ -85,8 +85,6 @@ type actionCreateOptions struct {
 	env          []string
 	params       []string
 	quotaProfile string
-	cpuQuota     string
-	memoryQuota  string
 }
 
 type actionCreateSpec struct {
@@ -132,8 +130,6 @@ type actionCreateHTTPSpec struct {
 
 type actionCreateQuota struct {
 	Profile string `yaml:"profile"`
-	CPU     string `yaml:"cpu"`
-	Memory  string `yaml:"memory"`
 }
 
 type actionCreateMountOptions struct {
@@ -278,8 +274,6 @@ func NewCreateCommand(cfgPath *string, ioStreams *iostreams.IOStreams, getProvid
 	cmd.Flags().StringArrayVar(&opts.env, "env", []string{}, "container environment variable in key=value format (repeatable)")
 	cmd.Flags().StringArrayVarP(&opts.params, "param", "P", []string{}, "action parameter default in key=value format (repeatable)")
 	cmd.Flags().StringVar(&opts.quotaProfile, "quota", "", "quota profile: small|medium|large|xlarge")
-	cmd.Flags().StringVar(&opts.cpuQuota, "cpu-quota", "", "raw CPU quota enum override, e.g. CPU_QUOTA_1C")
-	cmd.Flags().StringVar(&opts.memoryQuota, "memory-quota", "", "raw memory quota enum override, e.g. MEMORY_QUOTA_2G")
 
 	return cmd
 }
@@ -358,19 +352,11 @@ func applyActionCreateOverrides(spec *actionCreateSpec, opts *actionCreateOption
 			spec.Parameters[k] = v
 		}
 	}
-	if changed("quota") || changed("cpu-quota") || changed("memory-quota") {
+	if changed("quota") {
 		if spec.Quota == nil {
 			spec.Quota = &actionCreateQuota{}
 		}
-		if changed("quota") {
-			spec.Quota.Profile = opts.quotaProfile
-		}
-		if changed("cpu-quota") {
-			spec.Quota.CPU = opts.cpuQuota
-		}
-		if changed("memory-quota") {
-			spec.Quota.Memory = opts.memoryQuota
-		}
+		spec.Quota.Profile = opts.quotaProfile
 	}
 
 	if !changed("job-name") && !changed("image") && !changed("command") && !changed("args") && !changed("env") {
@@ -582,39 +568,21 @@ func lowerActionCreateJob(job *actionCreateJobSpec) (*openv1alpha1commons.JobSpe
 }
 
 func lowerActionCreateQuota(quota *actionCreateQuota) (*openv1alpha1commons.Quota, error) {
-	if quota.Profile != "" && (quota.CPU != "" || quota.Memory != "") {
-		return nil, errors.New("quota.profile cannot be combined with quota.cpu or quota.memory")
+	if quota.Profile == "" {
+		return &openv1alpha1commons.Quota{}, nil
 	}
-	if quota.Profile != "" {
-		switch strings.ToLower(quota.Profile) {
-		case "small":
-			return &openv1alpha1commons.Quota{Cpu: openv1alpha1commons.Quota_CPU_QUOTA_1C, Memory: openv1alpha1commons.Quota_MEMORY_QUOTA_2G}, nil
-		case "medium":
-			return &openv1alpha1commons.Quota{Cpu: openv1alpha1commons.Quota_CPU_QUOTA_2C, Memory: openv1alpha1commons.Quota_MEMORY_QUOTA_4G}, nil
-		case "large":
-			return &openv1alpha1commons.Quota{Cpu: openv1alpha1commons.Quota_CPU_QUOTA_4C, Memory: openv1alpha1commons.Quota_MEMORY_QUOTA_8G}, nil
-		case "xlarge":
-			return &openv1alpha1commons.Quota{Cpu: openv1alpha1commons.Quota_CPU_QUOTA_8C, Memory: openv1alpha1commons.Quota_MEMORY_QUOTA_16G}, nil
-		default:
-			return nil, fmt.Errorf("unknown quota profile %q", quota.Profile)
-		}
+	switch strings.ToLower(quota.Profile) {
+	case "small":
+		return &openv1alpha1commons.Quota{Cpu: openv1alpha1commons.Quota_CPU_QUOTA_1C, Memory: openv1alpha1commons.Quota_MEMORY_QUOTA_2G}, nil
+	case "medium":
+		return &openv1alpha1commons.Quota{Cpu: openv1alpha1commons.Quota_CPU_QUOTA_2C, Memory: openv1alpha1commons.Quota_MEMORY_QUOTA_4G}, nil
+	case "large":
+		return &openv1alpha1commons.Quota{Cpu: openv1alpha1commons.Quota_CPU_QUOTA_4C, Memory: openv1alpha1commons.Quota_MEMORY_QUOTA_8G}, nil
+	case "xlarge":
+		return &openv1alpha1commons.Quota{Cpu: openv1alpha1commons.Quota_CPU_QUOTA_8C, Memory: openv1alpha1commons.Quota_MEMORY_QUOTA_16G}, nil
+	default:
+		return nil, fmt.Errorf("unknown quota profile %q (valid: small, medium, large, xlarge)", quota.Profile)
 	}
-
-	out := &openv1alpha1commons.Quota{}
-	var err error
-	if quota.CPU != "" {
-		out.Cpu, err = parseActionCreateCPUQuota(quota.CPU)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if quota.Memory != "" {
-		out.Memory, err = parseActionCreateMemoryQuota(quota.Memory)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return out, nil
 }
 
 func validateActionForCreate(action *openv1alpha1resource.Action) error {
@@ -722,28 +690,6 @@ func parseActionCreateKeyValues(items []string, flagName string) (map[string]str
 		values[key] = value
 	}
 	return values, nil
-}
-
-func parseActionCreateCPUQuota(value string) (openv1alpha1commons.Quota_CPUQuota, error) {
-	key := strings.ToUpper(strings.TrimSpace(value))
-	if !strings.HasPrefix(key, "CPU_QUOTA_") {
-		key = "CPU_QUOTA_" + key
-	}
-	if v, ok := openv1alpha1commons.Quota_CPUQuota_value[key]; ok {
-		return openv1alpha1commons.Quota_CPUQuota(v), nil
-	}
-	return openv1alpha1commons.Quota_CPU_QUOTA_UNSPECIFIED, fmt.Errorf("unknown CPU quota %q", value)
-}
-
-func parseActionCreateMemoryQuota(value string) (openv1alpha1commons.Quota_MemoryQuota, error) {
-	key := strings.ToUpper(strings.TrimSpace(value))
-	if !strings.HasPrefix(key, "MEMORY_QUOTA_") {
-		key = "MEMORY_QUOTA_" + key
-	}
-	if v, ok := openv1alpha1commons.Quota_MemoryQuota_value[key]; ok {
-		return openv1alpha1commons.Quota_MemoryQuota(v), nil
-	}
-	return openv1alpha1commons.Quota_MEMORY_QUOTA_UNSPECIFIED, fmt.Errorf("unknown memory quota %q", value)
 }
 
 func parseActionCreateHTTPMethod(value string) (openv1alpha1commons.HttpJobSpec_HttpMethod, error) {

--- a/pkg/cmd/action/create_test.go
+++ b/pkg/cmd/action/create_test.go
@@ -16,6 +16,8 @@ package action
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -24,6 +26,7 @@ import (
 
 	openv1alpha1commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
 	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"connectrpc.com/connect"
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/stretchr/testify/assert"
@@ -89,7 +92,7 @@ func TestCreateCommandDryRunInlineJSON(t *testing.T) {
 		"--command", `python "run script.py"`,
 		"--env", "FOO=bar",
 		"--param", "X=default",
-		"--quota-profile", "small",
+		"--quota", "small",
 		"-o", "json",
 	})
 
@@ -251,4 +254,112 @@ func TestSplitActionCreateWords(t *testing.T) {
 
 func compactActionCreateJSON(input string) string {
 	return strings.Join(strings.Fields(input), "")
+}
+
+// --- fix-wave (Worker E) tests --------------------------------------------
+
+// The --example skeleton must ship the obvious sentinel so an unedited example
+// is easy to spot (warnActionCreateSentinels keys on exactly this string).
+func TestCreateCommandExampleUsesSentinel(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "missing-config.yaml")
+	var out bytes.Buffer
+	ioStreams := iostreams.Test(nil, &out, &bytes.Buffer{})
+	cmd := NewRootCommand(&cfgPath, ioStreams, config.Provide)
+	cmd.SetArgs([]string{"create", "--example"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, out.String(), actionCreateSentinelImage)
+}
+
+// A surviving sentinel image warns to stderr but does not fail the command.
+func TestWarnActionCreateSentinels(t *testing.T) {
+	t.Run("sentinel warns", func(t *testing.T) {
+		var errOut bytes.Buffer
+		ioStreams := iostreams.Test(nil, &bytes.Buffer{}, &errOut)
+		action := &openv1alpha1resource.Action{Spec: &openv1alpha1commons.ActionSpec{
+			Name: "a",
+			Jobs: []*openv1alpha1commons.JobSpec{{
+				Name: "job",
+				JobKind: &openv1alpha1commons.JobSpec_Container{Container: &openv1alpha1commons.ContainerJobSpec{
+					Image: actionCreateSentinelImage,
+				}},
+			}},
+		}}
+		warnActionCreateSentinels(action, ioStreams)
+		assert.Contains(t, errOut.String(), "sentinel")
+		assert.Contains(t, errOut.String(), `job "job"`)
+	})
+
+	t.Run("real image is silent", func(t *testing.T) {
+		var errOut bytes.Buffer
+		ioStreams := iostreams.Test(nil, &bytes.Buffer{}, &errOut)
+		action := &openv1alpha1resource.Action{Spec: &openv1alpha1commons.ActionSpec{
+			Name: "a",
+			Jobs: []*openv1alpha1commons.JobSpec{{
+				Name: "job",
+				JobKind: &openv1alpha1commons.JobSpec_Container{Container: &openv1alpha1commons.ContainerJobSpec{
+					Image: "ubuntu:22.04",
+				}},
+			}},
+		}}
+		warnActionCreateSentinels(action, ioStreams)
+		assert.Empty(t, errOut.String())
+	})
+}
+
+// Dry-run with the sentinel image emits the stderr warning end-to-end.
+func TestCreateCommandDryRunWarnsOnSentinel(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "missing-config.yaml")
+	var out, errOut bytes.Buffer
+	ioStreams := iostreams.Test(nil, &out, &errOut)
+	cmd := NewRootCommand(&cfgPath, ioStreams, config.Provide)
+	cmd.SetArgs([]string{
+		"create", "--dry-run",
+		"--name", "sentinel-action",
+		"--image", actionCreateSentinelImage,
+		"-o", "json",
+	})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, errOut.String(), "sentinel")
+}
+
+// D14: a ResourceExhausted / NO_SUBSCRIPTION connect error is classified as
+// "do not retry"; unrelated errors are not.
+func TestIsNoSubscriptionError(t *testing.T) {
+	// ResourceExhausted code -> true, even wrapped (mirrors api/action.go's %w).
+	re := connect.NewError(connect.CodeResourceExhausted, errors.New("quota exceeded"))
+	assert.True(t, isNoSubscriptionError(fmt.Errorf("failed to create action: %w", re)))
+
+	// NO_SUBSCRIPTION marker in the message -> true, regardless of code.
+	ns := connect.NewError(connect.CodeFailedPrecondition, errors.New("reason: NO_SUBSCRIPTION for org"))
+	assert.True(t, isNoSubscriptionError(ns))
+
+	// A different connect code without the marker -> false.
+	nf := connect.NewError(connect.CodeNotFound, errors.New("missing"))
+	assert.False(t, isNoSubscriptionError(nf))
+
+	// A non-connect error -> false.
+	assert.False(t, isNoSubscriptionError(errors.New("boom")))
+}
+
+// -P is the cocli shorthand for --param (D6); --args is the reconciled plan
+// flag name (was --arg). Both flow through to the lowered spec.
+func TestCreateCommandParamShorthandAndArgs(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "missing-config.yaml")
+	var out bytes.Buffer
+	ioStreams := iostreams.Test(nil, &out, &bytes.Buffer{})
+	cmd := NewRootCommand(&cfgPath, ioStreams, config.Provide)
+	cmd.SetArgs([]string{
+		"create", "--dry-run",
+		"--name", "flag-action",
+		"--image", "ubuntu:22.04",
+		"--command", "echo hi",
+		"-P", "X=default",
+		"--args=--verbose",
+		"-o", "json",
+	})
+	require.NoError(t, cmd.Execute())
+	got := compactActionCreateJSON(out.String())
+	assert.Contains(t, got, `"X":"default"`)
+	assert.Contains(t, got, `"--verbose"`)
 }

--- a/pkg/cmd/action/create_test.go
+++ b/pkg/cmd/action/create_test.go
@@ -1,0 +1,254 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	openv1alpha1commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeActionCreateTestConfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(path, []byte(`current-profile: test
+profiles:
+  - name: test
+    endpoint: https://openapi.mock.coscene.com
+    token: test-token
+    org: test-org
+    project: test-project
+    project-name: projects/p1
+`), 0644)
+	require.NoError(t, err)
+	return path
+}
+
+func TestCreateCommandExample(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "missing-config.yaml")
+	var out bytes.Buffer
+	ioStreams := iostreams.Test(nil, &out, &bytes.Buffer{})
+	cmd := NewRootCommand(&cfgPath, ioStreams, config.Provide)
+	cmd.SetArgs([]string{"create", "--example"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, out.String(), "name: my-action")
+	assert.Contains(t, out.String(), "quota:")
+	assert.Contains(t, out.String(), "profile: small")
+}
+
+func TestCreateCommandDryRunDoesNotRequireConfig(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "missing-config.yaml")
+	var out bytes.Buffer
+	ioStreams := iostreams.Test(nil, &out, &bytes.Buffer{})
+	cmd := NewRootCommand(&cfgPath, ioStreams, config.Provide)
+	cmd.SetArgs([]string{
+		"create",
+		"--dry-run",
+		"--name", "local-action",
+		"--image", "ubuntu:22.04",
+		"-o", "json",
+	})
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, compactActionCreateJSON(out.String()), `"name":"local-action"`)
+}
+
+func TestCreateCommandDryRunInlineJSON(t *testing.T) {
+	cfgPath := writeActionCreateTestConfig(t)
+	var out bytes.Buffer
+	ioStreams := iostreams.Test(nil, &out, &bytes.Buffer{})
+	cmd := NewRootCommand(&cfgPath, ioStreams, config.Provide)
+	cmd.SetArgs([]string{
+		"create",
+		"--dry-run",
+		"--name", "inline-action",
+		"--image", "ubuntu:22.04",
+		"--command", `python "run script.py"`,
+		"--env", "FOO=bar",
+		"--param", "X=default",
+		"--quota-profile", "small",
+		"-o", "json",
+	})
+
+	require.NoError(t, cmd.Execute())
+	raw := out.String()
+	got := compactActionCreateJSON(raw)
+	assert.Contains(t, got, `"name":"inline-action"`)
+	assert.Contains(t, got, `"image":"ubuntu:22.04"`)
+	assert.Contains(t, raw, `"run script.py"`)
+	assert.Contains(t, got, `"FOO":"bar"`)
+	assert.Contains(t, got, `"cpu":"CPU_QUOTA_1C"`)
+	assert.Contains(t, got, `"memory":"MEMORY_QUOTA_2G"`)
+}
+
+func TestCreateCommandDryRunTableOutput(t *testing.T) {
+	cfgPath := writeActionCreateTestConfig(t)
+	var out bytes.Buffer
+	ioStreams := iostreams.Test(nil, &out, &bytes.Buffer{})
+	cmd := NewRootCommand(&cfgPath, ioStreams, config.Provide)
+	cmd.SetArgs([]string{
+		"create",
+		"--dry-run",
+		"--name", "table-action",
+		"--image", "ubuntu:22.04",
+		"-o", "table",
+	})
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, out.String(), "table-action")
+}
+
+func TestCreateCommandDryRunStdinAndFlagOverrides(t *testing.T) {
+	cfgPath := writeActionCreateTestConfig(t)
+	var out bytes.Buffer
+	spec := `name: file-action
+jobs:
+  - name: step
+    container:
+      image: old-image
+      command: ["echo", "{{parameters.X}}"]
+parameters:
+  X: old
+quota:
+  cpu: CPU_QUOTA_2C
+  memory: MEMORY_QUOTA_4G
+`
+	ioStreams := iostreams.Test(io.NopCloser(strings.NewReader(spec)), &out, &bytes.Buffer{})
+	cmd := NewRootCommand(&cfgPath, ioStreams, config.Provide)
+	cmd.SetArgs([]string{
+		"create",
+		"--dry-run",
+		"-f", "-",
+		"--name", "flag-action",
+		"--image", "new-image",
+		"--env", "A=B",
+		"-o", "json",
+	})
+
+	require.NoError(t, cmd.Execute())
+	got := compactActionCreateJSON(out.String())
+	assert.Contains(t, got, `"name":"flag-action"`)
+	assert.Contains(t, got, `"image":"new-image"`)
+	assert.Contains(t, got, `"A":"B"`)
+	assert.Contains(t, got, `"X":"old"`)
+	assert.Contains(t, got, `"cpu":"CPU_QUOTA_2C"`)
+	assert.NotContains(t, got, "old-image")
+}
+
+func TestLoadActionCreateSpecAcceptsProtoJSONWrapper(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "spec.json")
+	err := os.WriteFile(path, []byte(`{
+  "spec": {
+    "name": "json-action",
+    "jobs": [
+      {
+        "name": "job",
+        "container": {
+          "image": "ubuntu:22.04",
+          "command": ["echo", "ok"]
+        }
+      }
+    ],
+    "outputOptions": {"saveMode": "APPEND"},
+    "storageOptions": {
+      "containerStorageBytes": 123,
+      "ssdOptions": {"useSsd": true, "mountPath": "/ssd"}
+    }
+  }
+}`), 0644)
+	require.NoError(t, err)
+
+	spec, err := loadActionCreateSpec(path, nil)
+	require.NoError(t, err)
+	action, err := lowerActionCreateSpec(spec)
+	require.NoError(t, err)
+
+	assert.Equal(t, "json-action", action.GetSpec().GetName())
+	assert.Equal(t, openv1alpha1commons.OutputOptions_APPEND, action.GetSpec().GetOutputOptions().GetSaveMode())
+	assert.Equal(t, int64(123), action.GetSpec().GetStorageOptions().GetContainerStorageBytes())
+	assert.True(t, action.GetSpec().GetStorageOptions().GetSsdOptions().GetUseSsd())
+	assert.Equal(t, "/ssd", action.GetSpec().GetStorageOptions().GetSsdOptions().GetMountPath())
+}
+
+func TestLowerActionCreateQuota(t *testing.T) {
+	profile, err := lowerActionCreateQuota(&actionCreateQuota{Profile: "xlarge"})
+	require.NoError(t, err)
+	assert.Equal(t, openv1alpha1commons.Quota_CPU_QUOTA_8C, profile.Cpu)
+	assert.Equal(t, openv1alpha1commons.Quota_MEMORY_QUOTA_16G, profile.Memory)
+
+	raw, err := lowerActionCreateQuota(&actionCreateQuota{CPU: "4C", Memory: "MEMORY_QUOTA_8G"})
+	require.NoError(t, err)
+	assert.Equal(t, openv1alpha1commons.Quota_CPU_QUOTA_4C, raw.Cpu)
+	assert.Equal(t, openv1alpha1commons.Quota_MEMORY_QUOTA_8G, raw.Memory)
+
+	_, err = lowerActionCreateQuota(&actionCreateQuota{Profile: "small", CPU: "CPU_QUOTA_1C"})
+	assert.Error(t, err)
+}
+
+func TestLowerActionCreateRejectsBothJobKinds(t *testing.T) {
+	_, err := lowerActionCreateSpec(&actionCreateSpec{
+		Name: "bad",
+		Jobs: []actionCreateJobSpec{{
+			Name:      "job",
+			Container: &actionCreateContainerSpec{Image: "img"},
+			HTTP:      &actionCreateHTTPSpec{Method: "GET", URL: "https://example.com"},
+		}},
+	})
+	assert.Error(t, err)
+}
+
+func TestValidateActionForCreate(t *testing.T) {
+	action := &openv1alpha1resource.Action{Spec: &openv1alpha1commons.ActionSpec{
+		Name: "valid",
+		Jobs: []*openv1alpha1commons.JobSpec{{
+			JobKind: &openv1alpha1commons.JobSpec_Container{Container: &openv1alpha1commons.ContainerJobSpec{
+				Image:   "img",
+				Command: []string{"echo {{parameters.X}}"},
+			}},
+		}},
+		Parameters: map[string]string{"X": "default"},
+	}}
+	require.NoError(t, validateActionForCreate(action))
+	assert.Equal(t, "job", action.Spec.Jobs[0].Name)
+
+	action.Spec.Parameters = nil
+	err := validateActionForCreate(action)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), `parameter "X" is referenced but not defined`)
+}
+
+func TestSplitActionCreateWords(t *testing.T) {
+	words, err := splitActionCreateWords(`python "run script.py" --flag=value`)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"python", "run script.py", "--flag=value"}, words)
+
+	_, err = splitActionCreateWords(`python "unterminated`)
+	assert.Error(t, err)
+}
+
+func compactActionCreateJSON(input string) string {
+	return strings.Join(strings.Fields(input), "")
+}

--- a/pkg/cmd/action/create_test.go
+++ b/pkg/cmd/action/create_test.go
@@ -76,7 +76,10 @@ func TestCreateCommandDryRunDoesNotRequireConfig(t *testing.T) {
 	})
 
 	require.NoError(t, cmd.Execute())
-	assert.Contains(t, compactActionCreateJSON(out.String()), `"name":"local-action"`)
+	got := compactActionCreateJSON(out.String())
+	assert.Contains(t, got, `"name":"local-action"`)
+	// CLI-built single job defaults to "main" (no --job-name flag anymore).
+	assert.Contains(t, got, `"name":"main"`)
 }
 
 func TestCreateCommandDryRunInlineJSON(t *testing.T) {
@@ -230,7 +233,7 @@ func TestValidateActionForCreate(t *testing.T) {
 		Parameters: map[string]string{"X": "default"},
 	}}
 	require.NoError(t, validateActionForCreate(action))
-	assert.Equal(t, "job", action.Spec.Jobs[0].Name)
+	assert.Equal(t, "main", action.Spec.Jobs[0].Name)
 
 	action.Spec.Parameters = nil
 	err := validateActionForCreate(action)
@@ -337,9 +340,10 @@ func TestIsNoSubscriptionError(t *testing.T) {
 	assert.False(t, isNoSubscriptionError(errors.New("boom")))
 }
 
-// -P is the cocli shorthand for --param (D6); --args is the reconciled plan
-// flag name (was --arg). Both flow through to the lowered spec.
-func TestCreateCommandParamShorthandAndArgs(t *testing.T) {
+// -P is the cocli shorthand for --param (D6). --command is shell-split
+// (quote-aware) into the job's command token list, so flags ride inside the
+// command line instead of a separate --args flag.
+func TestCreateCommandParamShorthandAndCommandSplit(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "missing-config.yaml")
 	var out bytes.Buffer
 	ioStreams := iostreams.Test(nil, &out, &bytes.Buffer{})
@@ -348,9 +352,8 @@ func TestCreateCommandParamShorthandAndArgs(t *testing.T) {
 		"create", "--dry-run",
 		"--name", "flag-action",
 		"--image", "ubuntu:22.04",
-		"--command", "echo hi",
+		"--command", "echo hi --verbose",
 		"-P", "X=default",
-		"--args=--verbose",
 		"-o", "json",
 	})
 	require.NoError(t, cmd.Execute())

--- a/pkg/cmd/action/create_test.go
+++ b/pkg/cmd/action/create_test.go
@@ -136,8 +136,7 @@ jobs:
 parameters:
   X: old
 quota:
-  cpu: CPU_QUOTA_2C
-  memory: MEMORY_QUOTA_4G
+  profile: large
 `
 	ioStreams := iostreams.Test(io.NopCloser(strings.NewReader(spec)), &out, &bytes.Buffer{})
 	cmd := NewRootCommand(&cfgPath, ioStreams, config.Provide)
@@ -157,7 +156,7 @@ quota:
 	assert.Contains(t, got, `"image":"new-image"`)
 	assert.Contains(t, got, `"A":"B"`)
 	assert.Contains(t, got, `"X":"old"`)
-	assert.Contains(t, got, `"cpu":"CPU_QUOTA_2C"`)
+	assert.Contains(t, got, `"cpu":"CPU_QUOTA_4C"`)
 	assert.NotContains(t, got, "old-image")
 }
 
@@ -197,18 +196,14 @@ func TestLoadActionCreateSpecAcceptsProtoJSONWrapper(t *testing.T) {
 }
 
 func TestLowerActionCreateQuota(t *testing.T) {
-	profile, err := lowerActionCreateQuota(&actionCreateQuota{Profile: "xlarge"})
+	quota, err := lowerActionCreateQuota(&actionCreateQuota{Profile: "xlarge"})
 	require.NoError(t, err)
-	assert.Equal(t, openv1alpha1commons.Quota_CPU_QUOTA_8C, profile.Cpu)
-	assert.Equal(t, openv1alpha1commons.Quota_MEMORY_QUOTA_16G, profile.Memory)
+	assert.Equal(t, openv1alpha1commons.Quota_CPU_QUOTA_8C, quota.Cpu)
+	assert.Equal(t, openv1alpha1commons.Quota_MEMORY_QUOTA_16G, quota.Memory)
 
-	raw, err := lowerActionCreateQuota(&actionCreateQuota{CPU: "4C", Memory: "MEMORY_QUOTA_8G"})
-	require.NoError(t, err)
-	assert.Equal(t, openv1alpha1commons.Quota_CPU_QUOTA_4C, raw.Cpu)
-	assert.Equal(t, openv1alpha1commons.Quota_MEMORY_QUOTA_8G, raw.Memory)
-
-	_, err = lowerActionCreateQuota(&actionCreateQuota{Profile: "small", CPU: "CPU_QUOTA_1C"})
+	_, err = lowerActionCreateQuota(&actionCreateQuota{Profile: "huge"})
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "valid: small, medium, large, xlarge")
 }
 
 func TestLowerActionCreateRejectsBothJobKinds(t *testing.T) {

--- a/pkg/cmd/action/delete.go
+++ b/pkg/cmd/action/delete.go
@@ -1,0 +1,98 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/internal/prompts"
+	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// deleteTriggerNote is the one-line side-effect warning surfaced in both the
+// confirmation prompt and the help text. Delete is a soft delete on the backend
+// that also cascades to soft-delete every trigger bound to the action (matrix
+// repo.Delete, one transaction). cocli cannot count the affected triggers (the
+// RPC returns Empty), so the warning is carried by wording, not a pre-delete
+// query — see plan D4/U3/F8.
+const deleteTriggerNote = "This also disables any triggers bound to it."
+
+func NewDeleteCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(string) config.Provider) *cobra.Command {
+	var (
+		force       = false
+		projectSlug = ""
+	)
+
+	cmd := &cobra.Command{
+		Use:   "delete <action-resource-name/id> [-p <working-project-slug>] [-f]",
+		Short: "Delete an action.",
+		Long: "Delete an action by resource name or id.\n\n" +
+			"Delete is a soft delete. " + deleteTriggerNote + " The deleted action\n" +
+			"no longer appears in `cocli action list`. Historical runs are unaffected\n" +
+			"(they are snapshotted at run time).",
+		Example: "  # Delete an action, prompting for confirmation (also disables its triggers):\n" +
+			"  cocli action delete my-action -p my-project\n\n" +
+			"  # Delete without the confirmation prompt:\n" +
+			"  cocli action delete my-action -p my-project -f",
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			// Get current profile.
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
+			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
+			if err != nil {
+				log.Fatalf("unable to get project name: %v", err)
+			}
+
+			// Resolve the action name/id first (client-side). The resolve-first
+			// pattern gives a clean not-found message even though the backend
+			// delete is idempotent (an unknown id succeeds); it depends on
+			// ActionId2Name wrapping its error with %w so the NotFound code
+			// survives (api/action.go, plan D7/F2).
+			actionName, err := pm.ActionCli().ActionId2Name(cmd.Context(), args[0], proj)
+			if utils.IsConnectErrorWithCode(err, connect.CodeNotFound) {
+				io.Printf("failed to find action: %s in project: %s\n", args[0], proj)
+				return
+			} else if err != nil {
+				log.Fatalf("failed to convert action id to name: %v", err)
+			}
+
+			// Confirm deletion unless forced. The prompt states the trigger
+			// side effect so the user is not surprised (plan F8).
+			if !force {
+				if confirmed := prompts.PromptYN("Delete this action? "+deleteTriggerNote, io); !confirmed {
+					io.Println("Delete action aborted.")
+					return
+				}
+			}
+
+			// Delete the action.
+			if err = pm.ActionCli().DeleteAction(cmd.Context(), actionName); err != nil {
+				log.Fatalf("failed to delete action: %v", err)
+			}
+
+			io.Printf("Action successfully deleted.\n")
+		},
+	}
+
+	cmd.Flags().BoolVarP(&force, "force", "f", force, "Force delete without confirmation")
+	cmd.Flags().StringVarP(&projectSlug, "project", "p", "", "the slug of the working project")
+
+	return cmd
+}

--- a/pkg/cmd/action/delete_test.go
+++ b/pkg/cmd/action/delete_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The delete command must register with the -p/--project and -f/--force flags.
+func TestDeleteCommandFlags(t *testing.T) {
+	cfgPath := setupActionCmdTestConfigPath(t)
+	var buf bytes.Buffer
+	io := iostreams.Test(nil, &buf, &buf)
+	cmd := NewRootCommand(&cfgPath, io, config.Provide)
+
+	deleteCmd, _, err := cmd.Find([]string{"delete"})
+	require.NoError(t, err)
+	assert.Equal(t, "delete", deleteCmd.Name())
+	assert.NotEmpty(t, deleteCmd.Short)
+	assert.NotNil(t, deleteCmd.Flag("project"), "flag --project not found")
+	assert.NotNil(t, deleteCmd.Flag("force"), "flag --force not found")
+	assert.Equal(t, "p", deleteCmd.Flag("project").Shorthand)
+	assert.Equal(t, "f", deleteCmd.Flag("force").Shorthand)
+}
+
+// delete requires exactly one positional argument (the action resource-name/id).
+func TestDeleteCommandRequiresExactlyOneArg(t *testing.T) {
+	cfgPath := setupActionCmdTestConfigPath(t)
+	var buf bytes.Buffer
+	io := iostreams.Test(nil, &buf, &buf)
+	cmd := NewRootCommand(&cfgPath, io, config.Provide)
+
+	deleteCmd, _, err := cmd.Find([]string{"delete"})
+	require.NoError(t, err)
+	assert.Error(t, deleteCmd.Args(deleteCmd, []string{}), "zero args should be rejected")
+	assert.NoError(t, deleteCmd.Args(deleteCmd, []string{"a1"}))
+	assert.Error(t, deleteCmd.Args(deleteCmd, []string{"a1", "a2"}), "two args should be rejected")
+}
+
+// The trigger side-effect (plan F8) must be surfaced in the confirmation prompt
+// wording AND the help text, since cocli cannot count the cascaded triggers.
+func TestDeleteCommandSurfacesTriggerSideEffect(t *testing.T) {
+	cfgPath := setupActionCmdTestConfigPath(t)
+	var buf bytes.Buffer
+	io := iostreams.Test(nil, &buf, &buf)
+	cmd := NewRootCommand(&cfgPath, io, config.Provide)
+
+	deleteCmd, _, err := cmd.Find([]string{"delete"})
+	require.NoError(t, err)
+
+	// The constant that both the prompt and help text reuse names the effect.
+	assert.Contains(t, deleteTriggerNote, "triggers")
+	// Help text repeats the trigger note.
+	assert.Contains(t, deleteCmd.Long, deleteTriggerNote)
+}
+
+func setupActionCmdTestConfigPath(t *testing.T) string {
+	t.Helper()
+	return strings.TrimSpace(t.TempDir()) + "/test-config.yaml"
+}

--- a/pkg/cmd/action/get.go
+++ b/pkg/cmd/action/get.go
@@ -1,0 +1,84 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/internal/printer"
+	"github.com/coscene-io/cocli/internal/printer/printable"
+	"github.com/coscene-io/cocli/internal/printer/table"
+	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func NewGetCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(string) config.Provider) *cobra.Command {
+	var (
+		projectSlug  = ""
+		outputFormat = "table"
+	)
+
+	cmd := &cobra.Command{
+		Use:   "get <action-resource-name/id> [-p <working-project-slug>] [-o <output-format>]",
+		Short: "Get an action.",
+		Long: "Get an action by resource name or id.\n\n" +
+			"The -o yaml / -o json output is the full protojson Action (name, author, timestamps, spec) " +
+			"and is the input format consumed by `cocli action update -f`, so `get -o yaml` can be edited " +
+			"and fed back into `update` to round-trip.",
+		Args:                  cobra.ExactArgs(1),
+		DisableFlagsInUseLine: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			// Get current profile.
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
+			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
+			if err != nil {
+				log.Fatalf("unable to get project name: %v", err)
+			}
+
+			// Resolve the action name/id. The resolve-first pattern gives a clean
+			// client-side not-found message; this depends on ActionId2Name wrapping
+			// its underlying error with %w so the NotFound code survives (api/action.go).
+			actionName, err := pm.ActionCli().ActionId2Name(cmd.Context(), args[0], proj)
+			if utils.IsConnectErrorWithCode(err, connect.CodeNotFound) {
+				io.Printf("failed to find action: %s in project: %s\n", args[0], proj)
+				return
+			} else if err != nil {
+				log.Fatalf("failed to convert action id to name: %v", err)
+			}
+
+			// Fetch the action.
+			action, err := pm.ActionCli().GetByName(cmd.Context(), actionName)
+			if err != nil {
+				log.Fatalf("failed to get action: %v", err)
+			}
+
+			p, err := printer.Printer(outputFormat, &printer.Options{TableOpts: &table.PrintOpts{Verbose: true}})
+			if err != nil {
+				log.Fatal(err)
+			}
+			if err = p.PrintObj(printable.NewSingleAction(action), io.Out); err != nil {
+				log.Fatalf("failed to print action: %v", err)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&projectSlug, "project", "p", "", "the slug of the working project")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "output format (table|json|yaml)")
+
+	return cmd
+}

--- a/pkg/cmd/action/get_test.go
+++ b/pkg/cmd/action/get_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	openv1alpha1commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/internal/printer"
+	"github.com/coscene-io/cocli/internal/printer/printable"
+	"github.com/coscene-io/cocli/internal/printer/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The get command must register with the -p/--project and -o/--output flags.
+func TestGetCommandFlags(t *testing.T) {
+	cfgPath := setupGetTestConfigPath(t)
+	var buf bytes.Buffer
+	io := iostreams.Test(nil, &buf, &buf)
+	cmd := NewRootCommand(&cfgPath, io, config.Provide)
+
+	getCmd, _, err := cmd.Find([]string{"get"})
+	require.NoError(t, err)
+	assert.Equal(t, "get", getCmd.Name())
+	assert.NotEmpty(t, getCmd.Short)
+	assert.NotNil(t, getCmd.Flag("project"), "flag --project not found")
+	assert.NotNil(t, getCmd.Flag("output"), "flag --output not found")
+	// -p / -o shorthands must be wired.
+	assert.Equal(t, "p", getCmd.Flag("project").Shorthand)
+	assert.Equal(t, "o", getCmd.Flag("output").Shorthand)
+}
+
+// get requires exactly one positional argument (the action resource-name/id).
+func TestGetCommandRequiresExactlyOneArg(t *testing.T) {
+	cfgPath := setupGetTestConfigPath(t)
+	var buf bytes.Buffer
+	io := iostreams.Test(nil, &buf, &buf)
+	cmd := NewRootCommand(&cfgPath, io, config.Provide)
+
+	getCmd, _, err := cmd.Find([]string{"get"})
+	require.NoError(t, err)
+	assert.Error(t, getCmd.Args(getCmd, []string{}), "zero args should be rejected")
+	assert.NoError(t, getCmd.Args(getCmd, []string{"a1"}))
+	assert.Error(t, getCmd.Args(getCmd, []string{"a1", "a2"}), "two args should be rejected")
+}
+
+// Contract (F1): the -o yaml / -o json output produced by `get` is the full
+// protojson Action (name, author, spec) that `action update -f` will later
+// consume. These format tests pin that shape so the get -> edit -> update loop
+// round-trips. They exercise the exact printer + printable used by the command.
+func TestGetCommandOutputFormats(t *testing.T) {
+	action := &openv1alpha1resource.Action{
+		Name:   "projects/p1/actions/a1",
+		Author: "users/u1",
+		Spec: &openv1alpha1commons.ActionSpec{
+			Name:        "my-action",
+			Description: "desc",
+			Jobs: []*openv1alpha1commons.JobSpec{{
+				Name: "main",
+				JobKind: &openv1alpha1commons.JobSpec_Container{
+					Container: &openv1alpha1commons.ContainerJobSpec{Image: "ubuntu:22.04"},
+				},
+			}},
+		},
+	}
+
+	t.Run("json is protojson Action", func(t *testing.T) {
+		out := renderSingleAction(t, "json", action)
+		compact := strings.Join(strings.Fields(out), "")
+		assert.Contains(t, compact, `"name":"projects/p1/actions/a1"`)
+		assert.Contains(t, compact, `"author":"users/u1"`)
+		assert.Contains(t, compact, `"image":"ubuntu:22.04"`)
+	})
+
+	t.Run("yaml is protojson Action", func(t *testing.T) {
+		out := renderSingleAction(t, "yaml", action)
+		assert.Contains(t, out, "projects/p1/actions/a1")
+		assert.Contains(t, out, "users/u1")
+		assert.Contains(t, out, "ubuntu:22.04")
+	})
+
+	t.Run("table renders the action title", func(t *testing.T) {
+		out := renderSingleAction(t, "table", action)
+		assert.Contains(t, out, "my-action")
+	})
+
+	t.Run("unsupported format errors", func(t *testing.T) {
+		_, err := printer.Printer("xml", &printer.Options{TableOpts: &table.PrintOpts{Verbose: true}})
+		require.Error(t, err)
+	})
+}
+
+// renderSingleAction prints an action through the exact printer + printable
+// pair the get command uses, returning the rendered string.
+func renderSingleAction(t *testing.T, format string, action *openv1alpha1resource.Action) string {
+	t.Helper()
+	p, err := printer.Printer(format, &printer.Options{TableOpts: &table.PrintOpts{Verbose: true}})
+	require.NoError(t, err)
+	var out bytes.Buffer
+	require.NoError(t, p.PrintObj(printable.NewSingleAction(action), &out))
+	return out.String()
+}
+
+func setupGetTestConfigPath(t *testing.T) string {
+	t.Helper()
+	return strings.TrimSpace(t.TempDir()) + "/test-config.yaml"
+}

--- a/pkg/cmd/action/root.go
+++ b/pkg/cmd/action/root.go
@@ -27,6 +27,7 @@ func NewRootCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 	}
 
 	cmd.AddCommand(NewCreateCommand(cfgPath, io, getProvider))
+	cmd.AddCommand(NewGetCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewListCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewListRunCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewRunCommand(cfgPath, io, getProvider))

--- a/pkg/cmd/action/root.go
+++ b/pkg/cmd/action/root.go
@@ -26,6 +26,7 @@ func NewRootCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 		Short: "Work with coScene action.",
 	}
 
+	cmd.AddCommand(NewCreateCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewListCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewListRunCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewRunCommand(cfgPath, io, getProvider))

--- a/pkg/cmd/action/root.go
+++ b/pkg/cmd/action/root.go
@@ -28,6 +28,8 @@ func NewRootCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 
 	cmd.AddCommand(NewCreateCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewGetCommand(cfgPath, io, getProvider))
+	cmd.AddCommand(NewUpdateCommand(cfgPath, io, getProvider))
+	cmd.AddCommand(NewDeleteCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewListCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewListRunCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewRunCommand(cfgPath, io, getProvider))

--- a/pkg/cmd/action/update.go
+++ b/pkg/cmd/action/update.go
@@ -1,0 +1,325 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+
+	openv1alpha1commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/internal/printer"
+	"github.com/coscene-io/cocli/internal/printer/printable"
+	"github.com/coscene-io/cocli/internal/printer/table"
+	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+	"gopkg.in/yaml.v3"
+)
+
+// updateMaskSpec is the only update_mask path the backend accepts (matrix
+// acPathToSel has a single entry, "spec"); it full-replaces the spec. cocli
+// always sends exactly this — the mask is never user-crafted (plan D2/D13/C4).
+var updateMaskSpec = []string{"spec"}
+
+func NewUpdateCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(string) config.Provider) *cobra.Command {
+	var (
+		projectSlug  = ""
+		filePath     = ""
+		dryRun       = false
+		outputFormat = "table"
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update <action-resource-name/id> -f <spec.yaml|json> [-p <working-project-slug>] [--dry-run] [-o <output-format>]",
+		Short: "Update an action's spec from a file.",
+		Long: "Update an action's spec, replacing it wholesale from a YAML/JSON file (`-` for stdin).\n\n" +
+			"The file is the full protojson Action produced by `cocli action get -o yaml/json`, so the\n" +
+			"get -> edit -> update loop round-trips. Output-only fields (name, author, timestamps) in the\n" +
+			"file are ignored; only the spec is written, selected by the positional action name/id.\n\n" +
+			"WARNING: update replaces the ENTIRE spec, including spec.labels. A spec that omits labels\n" +
+			"DETACHES all labels currently on the action. Keep the labels from the `get` dump (or set them\n" +
+			"explicitly) to preserve them.\n\n" +
+			"Masked secrets appear as `********` placeholders in a `get` dump; leave them unchanged and the\n" +
+			"backend restores the real values. --dry-run prints the spec that would be sent without any\n" +
+			"wire call.",
+		Example: "  # Round-trip: fetch, edit, then update:\n" +
+			"  cocli action get my-action -p my-project -o yaml > spec.yaml\n" +
+			"  # ...edit spec.yaml...\n" +
+			"  cocli action update my-action -p my-project -f spec.yaml\n\n" +
+			"  # Update from stdin:\n" +
+			"  cat spec.yaml | cocli action update my-action -p my-project -f -\n\n" +
+			"  # Preview the spec that would be sent without mutating anything:\n" +
+			"  cocli action update my-action -p my-project -f spec.yaml --dry-run",
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if filePath == "" {
+				log.Fatalf("a spec file is required: pass -f <file> (or -f - for stdin)")
+			}
+
+			// Load the spec with a proto-native loader that matches the format
+			// `action get -o yaml/json` emits, so the get -> edit -> update loop
+			// round-trips (plan D5/F1). Do NOT reuse create's strict
+			// loadActionCreateSpec — it hard-fails on a get dump.
+			spec, err := loadActionUpdateSpec(filePath, io.In)
+			if err != nil {
+				log.Fatalf("invalid action spec: %v", err)
+			}
+
+			// Reuse create's proto-level validation. Note (F7): it defaults an
+			// unnamed single job to "main" — acceptable here.
+			if err = validateActionForCreate(&openv1alpha1resource.Action{Spec: spec}); err != nil {
+				log.Fatalf("invalid action spec: %v", err)
+			}
+
+			printFormat := outputFormat
+			if dryRun && !cmd.Flags().Changed("output") {
+				printFormat = "yaml"
+			}
+			p, err := printer.Printer(printFormat, &printer.Options{TableOpts: &table.PrintOpts{Verbose: true}})
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			// --dry-run: print the spec that would be sent, make NO wire call.
+			if dryRun {
+				if err = p.PrintObj(printable.NewActionSpec(spec), io.Out); err != nil {
+					log.Fatalf("failed to print action spec: %v", err)
+				}
+				return
+			}
+
+			// Get current profile and resolve the action name/id (client-side,
+			// resolve-first — clean not-found message; plan D7/F2).
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
+			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
+			if err != nil {
+				log.Fatalf("unable to get project name: %v", err)
+			}
+			actionName, err := pm.ActionCli().ActionId2Name(cmd.Context(), args[0], proj)
+			if utils.IsConnectErrorWithCode(err, connect.CodeNotFound) {
+				io.Printf("failed to find action: %s in project: %s\n", args[0], proj)
+				return
+			} else if err != nil {
+				log.Fatalf("failed to convert action id to name: %v", err)
+			}
+
+			// Labels warning (plan D15/F4): the submitted spec replaces
+			// spec.labels wholesale. If it omits labels but the current action
+			// has some, the update DETACHES them — warn loudly before mutating.
+			warnActionUpdateLabelDetach(spec, func() (*openv1alpha1resource.Action, error) {
+				return pm.ActionCli().GetByName(cmd.Context(), actionName)
+			}, io)
+
+			// Update the action. Name selects the row; only spec is written.
+			updated, err := pm.ActionCli().UpdateAction(cmd.Context(), actionName, spec, updateMaskSpec)
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					os.Exit(1)
+				}
+				// A ResourceExhausted / NO_SUBSCRIPTION failure is almost always
+				// a missing permission grant, NOT a real quota limit — retrying
+				// will not help (plan D14, reused from create).
+				if isNoSubscriptionError(err) {
+					exitf(io, "failed to update action: %v\nlikely a missing permission grant, not a quota limit — do not retry", err)
+				}
+				log.Fatalf("failed to update action: %v", err)
+			}
+
+			// After a successful update, re-fetch to confirm the action is still
+			// retrievable (plan D14/F3). matrix UpdateAction echoes the request
+			// rather than the persisted row, and its blind WHERE-id update can
+			// silently write to a soft-deleted row and still return 200. A
+			// follow-up NotFound is the only visible signal of that footgun.
+			refetched, refetchErr := pm.ActionCli().GetByName(cmd.Context(), actionName)
+			if utils.IsConnectErrorWithCode(refetchErr, connect.CodeNotFound) {
+				io.Eprintf("warning: update reported success but the action is no longer retrievable; it may have been deleted.\n")
+				return
+			} else if refetchErr != nil {
+				// Non-NotFound re-fetch error: fall back to the echoed response
+				// so the caller still sees what was sent.
+				io.Eprintf("warning: update succeeded but re-fetching the action failed: %v\n", refetchErr)
+				refetched = updated
+			}
+
+			if err = p.PrintObj(printable.NewSingleAction(refetched), io.Out); err != nil {
+				log.Fatalf("failed to print action: %v", err)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&projectSlug, "project", "p", "", "the slug of the working project")
+	cmd.Flags().StringVarP(&filePath, "file", "f", "", "action spec YAML/JSON file (`-` for stdin), as produced by `cocli action get -o yaml`")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "validate and print the spec that would be sent without updating")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "output format (table|json|yaml)")
+
+	return cmd
+}
+
+// loadActionUpdateSpec reads a YAML/JSON action document (or stdin for `-`) and
+// extracts its ActionSpec via a proto-native path: parse to a generic value,
+// re-encode as JSON, then protojson.Unmarshal into an Action with
+// DiscardUnknown so output-only fields a `get -o yaml/json` dump carries (name,
+// author, create/update times) are tolerated rather than rejected. This is the
+// exact format `action get` emits, so the get -> edit -> update loop round-trips
+// (plan D5/F1). It deliberately does NOT reuse create's strict
+// loadActionCreateSpec (KnownFields + profile-quota YAML), which hard-fails on a
+// get dump.
+func loadActionUpdateSpec(path string, stdin io.Reader) (*openv1alpha1commons.ActionSpec, error) {
+	var (
+		data []byte
+		err  error
+	)
+	if path == "-" {
+		if stdin == nil {
+			return nil, errors.New("stdin is not available")
+		}
+		data, err = io.ReadAll(stdin)
+	} else {
+		data, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "read action spec")
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, errors.New("action spec is empty")
+	}
+
+	// Parse as YAML into a generic value. JSON is a subset of YAML, so this
+	// accepts both `get -o yaml` (snake_case protojson) and `get -o json`.
+	var generic interface{}
+	if err = yaml.Unmarshal(data, &generic); err != nil {
+		return nil, errors.Wrap(err, "parse action spec")
+	}
+	// yaml.v3 decodes mappings into map[string]interface{} when keys are
+	// strings, but nested non-string keys would break json.Marshal; normalize
+	// defensively.
+	normalized, err := normalizeActionUpdateYAML(generic)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse action spec")
+	}
+
+	jsonBytes, err := json.Marshal(normalized)
+	if err != nil {
+		return nil, errors.Wrap(err, "encode action spec")
+	}
+
+	// Preferred shape: the full protojson Action a `get -o yaml/json` dump
+	// emits (spec nested under a `spec:` key, alongside output-only fields).
+	action := &openv1alpha1resource.Action{}
+	if err = (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(jsonBytes, action); err != nil {
+		return nil, errors.Wrap(err, "parse action spec")
+	}
+	if action.GetSpec() != nil {
+		return action.GetSpec(), nil
+	}
+
+	// Fallback: a bare ActionSpec document (spec fields at the top level, no
+	// wrapping Action). Hand-authored specs commonly take this shape.
+	spec := &openv1alpha1commons.ActionSpec{}
+	if err = (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(jsonBytes, spec); err != nil {
+		return nil, errors.Wrap(err, "parse action spec")
+	}
+	if isEmptyActionSpec(spec) {
+		return nil, errors.New("action spec must not be empty")
+	}
+	return spec, nil
+}
+
+// isEmptyActionSpec reports whether an ActionSpec has no meaningful content —
+// used to reject a document that parsed but carried nothing an update could
+// write (e.g. only output-only Action fields, or an empty file body).
+func isEmptyActionSpec(spec *openv1alpha1commons.ActionSpec) bool {
+	return spec.GetName() == "" &&
+		spec.GetDescription() == "" &&
+		len(spec.GetLabels()) == 0 &&
+		len(spec.GetJobs()) == 0 &&
+		len(spec.GetParameters()) == 0 &&
+		spec.GetQuota() == nil &&
+		spec.GetMountOptions() == nil &&
+		spec.GetStorageOptions() == nil &&
+		spec.GetOutputOptions() == nil
+}
+
+// normalizeActionUpdateYAML converts any map[interface{}]interface{} that
+// yaml.v3 might produce into map[string]interface{} so json.Marshal accepts it.
+func normalizeActionUpdateYAML(v interface{}) (interface{}, error) {
+	switch typed := v.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(typed))
+		for k, val := range typed {
+			nv, err := normalizeActionUpdateYAML(val)
+			if err != nil {
+				return nil, err
+			}
+			out[k] = nv
+		}
+		return out, nil
+	case map[interface{}]interface{}:
+		out := make(map[string]interface{}, len(typed))
+		for k, val := range typed {
+			ks, ok := k.(string)
+			if !ok {
+				return nil, errors.Errorf("non-string map key %v", k)
+			}
+			nv, err := normalizeActionUpdateYAML(val)
+			if err != nil {
+				return nil, err
+			}
+			out[ks] = nv
+		}
+		return out, nil
+	case []interface{}:
+		out := make([]interface{}, 0, len(typed))
+		for _, item := range typed {
+			nv, err := normalizeActionUpdateYAML(item)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, nv)
+		}
+		return out, nil
+	default:
+		return v, nil
+	}
+}
+
+// warnActionUpdateLabelDetach warns to stderr when the submitted spec carries no
+// labels but the current action does — that update would DETACH all labels
+// (plan D15/F4). The check is best-effort: fetchCurrent is only called when the
+// submitted spec drops labels, and any fetch error stays silent (the update
+// proceeds regardless).
+func warnActionUpdateLabelDetach(spec *openv1alpha1commons.ActionSpec, fetchCurrent func() (*openv1alpha1resource.Action, error), io *iostreams.IOStreams) {
+	if len(spec.GetLabels()) > 0 {
+		return
+	}
+	current, err := fetchCurrent()
+	if err != nil || current == nil || current.GetSpec() == nil {
+		return
+	}
+	if len(current.GetSpec().GetLabels()) > 0 {
+		io.Eprintf("warning: the submitted spec has no labels but the action currently has %d; update will DETACH all of them.\n", len(current.GetSpec().GetLabels()))
+	}
+}

--- a/pkg/cmd/action/update_test.go
+++ b/pkg/cmd/action/update_test.go
@@ -1,0 +1,259 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	openv1alpha1commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/internal/printer"
+	"github.com/coscene-io/cocli/internal/printer/printable"
+	"github.com/coscene-io/cocli/internal/printer/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The update command must register with -p/--project, -f/--file, --dry-run and
+// -o/--output.
+func TestUpdateCommandFlags(t *testing.T) {
+	cfgPath := setupActionCmdTestConfigPath(t)
+	var buf bytes.Buffer
+	io := iostreams.Test(nil, &buf, &buf)
+	cmd := NewRootCommand(&cfgPath, io, config.Provide)
+
+	updateCmd, _, err := cmd.Find([]string{"update"})
+	require.NoError(t, err)
+	assert.Equal(t, "update", updateCmd.Name())
+	assert.NotEmpty(t, updateCmd.Short)
+	assert.NotNil(t, updateCmd.Flag("project"), "flag --project not found")
+	assert.NotNil(t, updateCmd.Flag("file"), "flag --file not found")
+	assert.NotNil(t, updateCmd.Flag("dry-run"), "flag --dry-run not found")
+	assert.NotNil(t, updateCmd.Flag("output"), "flag --output not found")
+	assert.Equal(t, "p", updateCmd.Flag("project").Shorthand)
+	assert.Equal(t, "f", updateCmd.Flag("file").Shorthand)
+	assert.Equal(t, "o", updateCmd.Flag("output").Shorthand)
+
+	// No inline field flags and no --example (plan Unit 9): update is
+	// file-based only.
+	assert.Nil(t, updateCmd.Flag("example"), "update must not expose --example")
+	assert.Nil(t, updateCmd.Flag("name"), "update must not expose inline field flags")
+	assert.Nil(t, updateCmd.Flag("image"), "update must not expose inline field flags")
+}
+
+// update requires exactly one positional argument (the action resource-name/id).
+func TestUpdateCommandRequiresExactlyOneArg(t *testing.T) {
+	cfgPath := setupActionCmdTestConfigPath(t)
+	var buf bytes.Buffer
+	io := iostreams.Test(nil, &buf, &buf)
+	cmd := NewRootCommand(&cfgPath, io, config.Provide)
+
+	updateCmd, _, err := cmd.Find([]string{"update"})
+	require.NoError(t, err)
+	assert.Error(t, updateCmd.Args(updateCmd, []string{}), "zero args should be rejected")
+	assert.NoError(t, updateCmd.Args(updateCmd, []string{"a1"}))
+	assert.Error(t, updateCmd.Args(updateCmd, []string{"a1", "a2"}), "two args should be rejected")
+}
+
+// cocli always sends exactly update_mask=["spec"] (plan D2/D13/C4).
+func TestUpdateMaskIsSpecOnly(t *testing.T) {
+	assert.Equal(t, []string{"spec"}, updateMaskSpec)
+}
+
+// dumpActionAs renders an Action through the exact printer + printable the get
+// command uses, returning the bytes an operator would capture with
+// `cocli action get -o <format>`.
+func dumpActionAs(t *testing.T, format string, action *openv1alpha1resource.Action) []byte {
+	t.Helper()
+	p, err := printer.Printer(format, &printer.Options{TableOpts: &table.PrintOpts{Verbose: true}})
+	require.NoError(t, err)
+	var out bytes.Buffer
+	require.NoError(t, p.PrintObj(printable.NewSingleAction(action), &out))
+	return out.Bytes()
+}
+
+// TestUpdateLoaderRoundTripsGetDump is the F1 guard: a `get -o yaml` (and
+// `-o json`) dump — which carries output-only fields name/author/timestamps and
+// a full spec — must parse cleanly into update's loader and yield the same spec.
+// This proves the get -> edit -> update loop round-trips (plan D5/F1). It is the
+// central reason update uses a proto-native loader rather than create's strict
+// profile-quota YAML loader.
+func TestUpdateLoaderRoundTripsGetDump(t *testing.T) {
+	action := &openv1alpha1resource.Action{
+		Name:   "projects/p1/actions/a1",
+		Author: "users/u1",
+		Spec: &openv1alpha1commons.ActionSpec{
+			Name:        "my-action",
+			Description: "desc",
+			Labels:      []string{"labels/l1", "labels/l2"},
+			Parameters:  map[string]string{"X": "default"},
+			Jobs: []*openv1alpha1commons.JobSpec{{
+				Name: "main",
+				JobKind: &openv1alpha1commons.JobSpec_Container{
+					Container: &openv1alpha1commons.ContainerJobSpec{
+						Image:   "ubuntu:22.04",
+						Command: []string{"python", "run.py"},
+						Env:     map[string]string{"COS_KEY": "value"},
+					},
+				},
+			}},
+			Quota: &openv1alpha1commons.Quota{
+				Cpu:    openv1alpha1commons.Quota_CPU_QUOTA_1C,
+				Memory: openv1alpha1commons.Quota_MEMORY_QUOTA_2G,
+			},
+		},
+	}
+
+	for _, format := range []string{"yaml", "json"} {
+		t.Run(format+" dump round-trips into loader", func(t *testing.T) {
+			dump := dumpActionAs(t, format, action)
+			spec, err := loadActionUpdateSpec("-", bytes.NewReader(dump))
+			require.NoError(t, err, "get -o %s output must parse cleanly into update's loader", format)
+
+			assert.Equal(t, "my-action", spec.GetName())
+			assert.Equal(t, "desc", spec.GetDescription())
+			assert.Equal(t, []string{"labels/l1", "labels/l2"}, spec.GetLabels())
+			require.Len(t, spec.GetJobs(), 1)
+			job := spec.GetJobs()[0]
+			assert.Equal(t, "main", job.GetName())
+			require.NotNil(t, job.GetContainer())
+			assert.Equal(t, "ubuntu:22.04", job.GetContainer().GetImage())
+			assert.Equal(t, []string{"python", "run.py"}, job.GetContainer().GetCommand())
+			assert.Equal(t, openv1alpha1commons.Quota_CPU_QUOTA_1C, spec.GetQuota().GetCpu())
+
+			// The loaded spec must survive create's proto-level validation so
+			// the command would accept it.
+			require.NoError(t, validateActionForCreate(&openv1alpha1resource.Action{Spec: spec}))
+		})
+	}
+}
+
+// A bare-spec file (just the ActionSpec, no wrapping Action) also loads: the
+// spec fields sit at the top level of the Action message, so a spec-shaped doc
+// parses identically. This keeps hand-authored specs working too.
+func TestUpdateLoaderAcceptsBareSpecShape(t *testing.T) {
+	specDump := []byte(`name: my-action
+description: desc
+jobs:
+  - name: main
+    container:
+      image: ubuntu:22.04
+`)
+	spec, err := loadActionUpdateSpec("-", bytes.NewReader(specDump))
+	require.NoError(t, err)
+	assert.Equal(t, "my-action", spec.GetName())
+	require.Len(t, spec.GetJobs(), 1)
+	assert.Equal(t, "ubuntu:22.04", spec.GetJobs()[0].GetContainer().GetImage())
+}
+
+// Output-only fields present in a get dump (createTime/updateTime and any future
+// server-only field) are tolerated via DiscardUnknown rather than rejected.
+func TestUpdateLoaderToleratesOutputOnlyFields(t *testing.T) {
+	dump := []byte(`name: projects/p1/actions/a1
+author: users/u1
+create_time: "2026-07-08T00:00:00Z"
+update_time: "2026-07-08T00:00:00Z"
+some_future_server_field: whatever
+spec:
+  name: my-action
+  jobs:
+    - name: main
+      container:
+        image: ubuntu:22.04
+`)
+	spec, err := loadActionUpdateSpec("-", bytes.NewReader(dump))
+	require.NoError(t, err)
+	assert.Equal(t, "my-action", spec.GetName())
+}
+
+// Empty stdin / empty file is rejected client-side before any wire call.
+func TestUpdateLoaderRejectsEmptyInput(t *testing.T) {
+	_, err := loadActionUpdateSpec("-", bytes.NewReader([]byte("   \n")))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+// A spec with no jobs is rejected client-side (reuses create's validation).
+func TestUpdateInvalidSpecRejectedClientSide(t *testing.T) {
+	spec, err := loadActionUpdateSpec("-", bytes.NewReader([]byte("name: my-action\n")))
+	require.NoError(t, err)
+	err = validateActionForCreate(&openv1alpha1resource.Action{Spec: spec})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "jobs cannot be empty")
+}
+
+// A RESOURCE_EXHAUSTED / NO_SUBSCRIPTION failure is detected as the no-retry
+// case so update surfaces the "missing grant, do not retry" message (plan D14).
+// This shares create's classifier; pin its behavior for the update path.
+func TestUpdateNoSubscriptionErrorClassification(t *testing.T) {
+	exhausted := connect.NewError(connect.CodeResourceExhausted, nil)
+	assert.True(t, isNoSubscriptionError(exhausted), "ResourceExhausted must be treated as no-retry")
+
+	notFound := connect.NewError(connect.CodeNotFound, nil)
+	assert.False(t, isNoSubscriptionError(notFound), "NotFound must not be treated as no-retry")
+}
+
+// warnActionUpdateLabelDetach warns only when the submitted spec drops labels
+// that the current action has (plan D15/F4).
+func TestUpdateLabelDetachWarning(t *testing.T) {
+	current := &openv1alpha1resource.Action{
+		Name: "projects/p1/actions/a1",
+		Spec: &openv1alpha1commons.ActionSpec{Labels: []string{"labels/l1"}},
+	}
+
+	fetch := func(a *openv1alpha1resource.Action) func() (*openv1alpha1resource.Action, error) {
+		return func() (*openv1alpha1resource.Action, error) { return a, nil }
+	}
+
+	t.Run("warns when spec omits labels the action has", func(t *testing.T) {
+		var errBuf bytes.Buffer
+		io := iostreams.Test(nil, &bytes.Buffer{}, &errBuf)
+		warnActionUpdateLabelDetach(&openv1alpha1commons.ActionSpec{}, fetch(current), io)
+		assert.Contains(t, errBuf.String(), "DETACH")
+	})
+
+	t.Run("silent when spec keeps labels", func(t *testing.T) {
+		var errBuf bytes.Buffer
+		io := iostreams.Test(nil, &bytes.Buffer{}, &errBuf)
+		warnActionUpdateLabelDetach(&openv1alpha1commons.ActionSpec{Labels: []string{"labels/l1"}}, fetch(current), io)
+		assert.Empty(t, errBuf.String())
+	})
+
+	t.Run("silent when the current action has no labels", func(t *testing.T) {
+		var errBuf bytes.Buffer
+		io := iostreams.Test(nil, &bytes.Buffer{}, &errBuf)
+		warnActionUpdateLabelDetach(&openv1alpha1commons.ActionSpec{}, fetch(&openv1alpha1resource.Action{Spec: &openv1alpha1commons.ActionSpec{}}), io)
+		assert.Empty(t, errBuf.String())
+	})
+}
+
+// Help text documents the label-detach data-loss path (plan D15/F4) and the
+// round-trip contract (F1).
+func TestUpdateHelpDocumentsLabelAndRoundTrip(t *testing.T) {
+	cfgPath := setupActionCmdTestConfigPath(t)
+	var buf bytes.Buffer
+	io := iostreams.Test(nil, &buf, &buf)
+	cmd := NewRootCommand(&cfgPath, io, config.Provide)
+
+	updateCmd, _, err := cmd.Find([]string{"update"})
+	require.NoError(t, err)
+	assert.Contains(t, updateCmd.Long, "label", "help must warn about label detach")
+	assert.Contains(t, strings.ToLower(updateCmd.Long), "get")
+}


### PR DESCRIPTION
get + api wrappers landed; delete/update commands follow.

## Landed so far
- `action get` command (commit d3f526c)
- `ActionId2Name` error-wrap fix (`%w`) so the resolve-first not-found UX works
- `api/action.go`: `DeleteAction` / `UpdateAction` wrappers mirroring `record.go`'s Delete/Update (UpdateAction sends `update_mask=["spec"]`, full spec replace; DeleteAction is soft + idempotent)
- SDK bump to the openapi build that publishes both RPCs

## Follow-up
- `action delete` / `action update` commands

Depends on openapi BSR `20260709002126-f5ec6f481038`.

**Do not merge until reviewed.**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coCLI/pr/187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786149290&installation_id=141984720&pr_number=187&repository=coscene-io%2FcoCLI&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoCLI%2Fpull%2F187&signature=b4475b00fd5f6462f1e38ad9edbfc1fda704d75111b06c7ff412d24cc478bc26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->