### PR TITLE
fix(record): fail --labels filter when a label is absent instead of returning unfiltered records

### DIFF
--- a/api/record.go
+++ b/api/record.go
@@ -29,7 +29,6 @@ import (
 	"github.com/coscene-io/cocli/internal/name"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
-	log "github.com/sirupsen/logrus"
 	"google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -544,7 +543,10 @@ func (c *recordClient) applyQueryFilter(ctx context.Context, msg *openv1alpha1se
 		return nil
 	}
 
-	filter := c.buildSearchFilter(ctx, opts)
+	filter, err := c.buildSearchFilter(ctx, opts)
+	if err != nil {
+		return err
+	}
 	if filter != "" {
 		msg.QueryFilter = &openv1alpha1service.SearchRecordsRequest_Filter{
 			Filter: filter,
@@ -554,7 +556,7 @@ func (c *recordClient) applyQueryFilter(ctx context.Context, msg *openv1alpha1se
 }
 
 // buildSearchFilter builds the filter string for the SearchRecords API using AIP-160 syntax.
-func (c *recordClient) buildSearchFilter(ctx context.Context, opts *SearchRecordsOptions) string {
+func (c *recordClient) buildSearchFilter(ctx context.Context, opts *SearchRecordsOptions) (string, error) {
 	var filters []string
 	if !opts.IncludeArchive {
 		filters = append(filters, "isArchived = false")
@@ -568,16 +570,19 @@ func (c *recordClient) buildSearchFilter(ctx context.Context, opts *SearchRecord
 	if len(opts.Labels) > 0 {
 		labelIDs, err := c.transformLabelsToIDs(ctx, opts.Project.String(), opts.Labels)
 		if err != nil {
-			// Log warning using logrus, don't fail the entire request
-			log.Warnf("failed to lookup labels: %v", err)
-		} else if len(labelIDs) > 0 {
-			quotedIDs := lo.Map(labelIDs, func(id string, _ int) string {
-				return fmt.Sprintf(`"%s"`, id)
-			})
-			filters = append(filters, fmt.Sprintf("relatedLabels.id in [%s]", strings.Join(quotedIDs, ", ")))
+			// Fail the request: silently dropping the label filter would return
+			// unfiltered results and mislead the caller into thinking they match.
+			return "", err
 		}
+		if len(labelIDs) == 0 {
+			return "", fmt.Errorf("labels not found: %v", strings.Join(opts.Labels, ","))
+		}
+		quotedIDs := lo.Map(labelIDs, func(id string, _ int) string {
+			return fmt.Sprintf(`"%s"`, id)
+		})
+		filters = append(filters, fmt.Sprintf("relatedLabels.id in [%s]", strings.Join(quotedIDs, ", ")))
 	}
-	return strings.Join(filters, " AND ")
+	return strings.Join(filters, " AND "), nil
 }
 
 func (c *recordClient) GenerateRecordThumbnailUploadUrl(ctx context.Context, recordName *name.Record) (string, error) {

--- a/api/record_test.go
+++ b/api/record_test.go
@@ -286,6 +286,53 @@ func TestRecordClient_SearchAll(t *testing.T) {
 	assert.Len(t, records, 2)
 }
 
+func TestRecordClient_Search_MissingLabelFailsWithoutFallback(t *testing.T) {
+	ctx := testutil.TestContext(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	project := &name.Project{ProjectID: "test-project"}
+	options := &SearchRecordsOptions{
+		Project: project,
+		// label2 is absent in the project; the request must fail instead of
+		// silently dropping the label filter and returning unfiltered records.
+		Labels:         []string{"label1", "label2"},
+		IncludeArchive: false,
+	}
+
+	// Label service resolves only label1, leaving label2 unmatched.
+	mockLabelService := &mockLabelServiceClient{
+		ctrl: ctrl,
+		listLabelsFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.ListLabelsRequest]) (*connect.Response[openv1alpha1service.ListLabelsResponse], error) {
+			return connect.NewResponse(&openv1alpha1service.ListLabelsResponse{
+				Labels: []*openv1alpha1resource.Label{
+					{Name: "projects/test-project/labels/label-id-1", DisplayName: "label1"},
+				},
+			}), nil
+		},
+	}
+
+	// Record search must never be reached when a label cannot be resolved.
+	mockRecordService := &mockRecordServiceClient{
+		ctrl: ctrl,
+		searchRecordsFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.SearchRecordsRequest]) (*connect.Response[openv1alpha1service.SearchRecordsResponse], error) {
+			t.Fatal("SearchRecords must not be called when a label is missing")
+			return nil, nil
+		},
+	}
+
+	client := NewRecordClient(mockRecordService, nil, nil, mockLabelService)
+
+	_, err := client.SearchWithPageToken(ctx, options)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "labels not found")
+	assert.Contains(t, err.Error(), "label2")
+
+	_, err = client.SearchAll(ctx, options)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "labels not found")
+}
+
 func TestRecordClient_RecordId2Name(t *testing.T) {
 	ctx := testutil.TestContext(t)
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
## Problem

`cocli record list --labels <name>` silently returned **all records** when a label could not be resolved in the project.

`transformLabelsToIDs` returns `labels not found: ...` when any requested label is missing, but `buildSearchFilter` swallowed that error with `log.Warnf` and continued **without** appending the label clause. The resulting filter carried only `isArchived = false`, so the search ran unfiltered. The warning is easy to miss, and the returned list reads as if it matched the label.

Partial matches were worse: `--labels real,typo` dropped the *entire* label filter, ignoring even the valid label.

## Fix

- `buildSearchFilter` now returns `(string, error)`.
- A label-resolution error (or zero resolved IDs) aborts the request, naming the unresolved label(s).
- The error propagates through `applyQueryFilter` → `SearchAll` / `SearchWithPageToken` → `record list`, which exits non-zero instead of printing a full record list.
- Removed the now-unused `logrus` import.

## Behavior

| Case | Before | After |
|---|---|---|
| Absent / typo label | warning line, **all records** returned | `labels not found: <name>`, no query sent, non-zero exit |
| Partial match (`real,typo`) | whole label filter dropped | fails, names the missing label |

## Tests

- New `TestRecordClient_Search_MissingLabelFailsWithoutFallback`: label service resolves 1 of 2 labels; asserts the request errors and `SearchRecords` is **never called** (guarded by `t.Fatal` on the record mock).
- `go build ./...`, `go vet ./api/...`, and full `go test ./...` all green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coCLI/pr/188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786699259&installation_id=141984720&pr_number=188&repository=coscene-io%2FcoCLI&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoCLI%2Fpull%2F188&signature=7ed4f5fb054c0f7a89f29b7e5e70ccc28aa9688eba45bb9acfded781d4ce5d2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->