### PR TITLE
fix(action): use server defaults with --skip-params

### DIFF
--- a/api/action_test.go
+++ b/api/action_test.go
@@ -271,15 +271,17 @@ func TestActionClient_CreateActionRun(t *testing.T) {
 	defer ctrl.Finish()
 
 	t.Run("success", func(t *testing.T) {
+		action := &openv1alpha1resource.Action{Name: "projects/p1/actions/a1"}
 		mockRun := &mockActionRunServiceClient{
 			ctrl: ctrl,
 			createActionRunFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.CreateActionRunRequest]) (*connect.Response[openv1alpha1resource.ActionRun], error) {
 				assert.Equal(t, "projects/p1", req.Msg.Parent)
+				assert.Same(t, action, req.Msg.ActionRun.Action)
 				return connect.NewResponse(&openv1alpha1resource.ActionRun{}), nil
 			},
 		}
 		client := NewActionClient(nil, mockRun)
-		err := client.CreateActionRun(ctx, &openv1alpha1resource.Action{Name: "projects/p1/actions/a1"}, &name.Record{ProjectID: "p1", RecordID: "r1"})
+		err := client.CreateActionRun(ctx, action, &name.Record{ProjectID: "p1", RecordID: "r1"})
 		assert.NoError(t, err)
 	})
 

--- a/pkg/cmd/action/run.go
+++ b/pkg/cmd/action/run.go
@@ -22,12 +22,12 @@ import (
 	"connectrpc.com/connect"
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/iostreams"
-	"github.com/coscene-io/cocli/internal/name"
 	"github.com/coscene-io/cocli/internal/prompts"
 	"github.com/coscene-io/cocli/internal/utils"
 	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
 )
 
 func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(string) config.Provider) *cobra.Command {
@@ -62,16 +62,16 @@ func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 			} else if err != nil {
 				log.Fatalf("failed to convert record id to name: %v", err)
 			}
+			act, err := pm.ActionCli().GetByName(cmd.Context(), actionName)
+			if err != nil {
+				log.Fatalf("failed to get action by name %s: %v", actionName, err)
+			}
 
 			var runParams map[string]string
 			if !skipParams {
 				if cmd.Flags().Changed("param") {
 					runParams = params
 				} else {
-					act, err := pm.ActionCli().GetByName(cmd.Context(), actionName)
-					if err != nil {
-						log.Fatalf("failed to get action by name %s: %v", actionName, err)
-					}
 					// prompt to ask for parameters
 					runParams = make(map[string]string, len(act.Spec.Parameters))
 					for k, v := range act.Spec.Parameters {
@@ -99,7 +99,7 @@ func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 			}
 
 			// Create action run
-			err = pm.ActionCli().CreateActionRun(cmd.Context(), newActionRunAction(actionName, runParams), recordName)
+			err = pm.ActionCli().CreateActionRun(cmd.Context(), newActionRunAction(act, runParams), recordName)
 			if err != nil {
 				log.Fatalf("failed to create action run: %v", err)
 			}
@@ -119,11 +119,11 @@ func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 	return cmd
 }
 
-func newActionRunAction(actionName *name.Action, parameters map[string]string) *openv1alpha1resource.Action {
-	return &openv1alpha1resource.Action{
-		Name: actionName.String(),
-		Spec: &openv1alpha1commons.ActionSpec{
-			Parameters: parameters,
-		},
+func newActionRunAction(action *openv1alpha1resource.Action, parameters map[string]string) *openv1alpha1resource.Action {
+	runAction := proto.Clone(action).(*openv1alpha1resource.Action)
+	if runAction.Spec == nil {
+		runAction.Spec = &openv1alpha1commons.ActionSpec{}
 	}
+	runAction.Spec.Parameters = parameters
+	return runAction
 }

--- a/pkg/cmd/action/run.go
+++ b/pkg/cmd/action/run.go
@@ -73,17 +73,13 @@ func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 				if cmd.Flags().Changed("param") {
 					runParams = params
 				} else {
-					// prompt to ask for parameters
-					runParams = make(map[string]string, len(act.Spec.Parameters))
-					for k, v := range act.Spec.Parameters {
-						runParams[k] = prompts.PromptString(fmt.Sprintf("Enter value for parameter %s", k), v)
-					}
+					runParams = promptActionRunParameters(act.Spec.Parameters, prompts.PromptString)
 				}
 			}
 
 			// Print final parameters
 			io.Println("\nThe final parameters in the action run to be created:")
-			if skipParams {
+			if skipParams || len(runParams) == 0 {
 				io.Println("Using default parameters configured on the server.")
 			} else {
 				for k, v := range runParams {
@@ -118,6 +114,17 @@ func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 	cmd.MarkFlagsMutuallyExclusive("skip-params", "param")
 
 	return cmd
+}
+
+func promptActionRunParameters(defaults map[string]string, prompt func(string, string) string) map[string]string {
+	overrides := make(map[string]string)
+	for key, defaultValue := range defaults {
+		value := prompt(fmt.Sprintf("Enter value for parameter %s", key), defaultValue)
+		if value != defaultValue {
+			overrides[key] = value
+		}
+	}
+	return overrides
 }
 
 func newActionRunAction(action *openv1alpha1resource.Action, parameters map[string]string) *openv1alpha1resource.Action {

--- a/pkg/cmd/action/run.go
+++ b/pkg/cmd/action/run.go
@@ -17,9 +17,12 @@ package action
 import (
 	"fmt"
 
+	openv1alpha1commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
 	"connectrpc.com/connect"
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/internal/name"
 	"github.com/coscene-io/cocli/internal/prompts"
 	"github.com/coscene-io/cocli/internal/utils"
 	"github.com/coscene-io/cocli/pkg/cmd_utils"
@@ -60,32 +63,31 @@ func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 				log.Fatalf("failed to convert record id to name: %v", err)
 			}
 
-			// Fetch action
-			act, err := pm.ActionCli().GetByName(cmd.Context(), actionName)
-			if err != nil {
-				log.Fatalf("failed to get action by name %s: %v", actionName, err)
-			}
-
+			var runParams map[string]string
 			if !skipParams {
-				if act.Spec.Parameters == nil {
-					act.Spec.Parameters = make(map[string]string)
-				}
 				if cmd.Flags().Changed("param") {
-					for k, v := range params {
-						act.Spec.Parameters[k] = v
-					}
+					runParams = params
 				} else {
+					act, err := pm.ActionCli().GetByName(cmd.Context(), actionName)
+					if err != nil {
+						log.Fatalf("failed to get action by name %s: %v", actionName, err)
+					}
 					// prompt to ask for parameters
+					runParams = make(map[string]string, len(act.Spec.Parameters))
 					for k, v := range act.Spec.Parameters {
-						act.Spec.Parameters[k] = prompts.PromptString(fmt.Sprintf("Enter value for parameter %s", k), v)
+						runParams[k] = prompts.PromptString(fmt.Sprintf("Enter value for parameter %s", k), v)
 					}
 				}
 			}
 
 			// Print final parameters
 			io.Println("\nThe final parameters in the action run to be created:")
-			for k, v := range act.Spec.Parameters {
-				io.Printf("%s: %s\n", k, v)
+			if skipParams {
+				io.Println("Using default parameters configured on the server.")
+			} else {
+				for k, v := range runParams {
+					io.Printf("%s: %s\n", k, v)
+				}
 			}
 
 			// Prompt user for confirmation
@@ -97,7 +99,7 @@ func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 			}
 
 			// Create action run
-			err = pm.ActionCli().CreateActionRun(cmd.Context(), act, recordName)
+			err = pm.ActionCli().CreateActionRun(cmd.Context(), newActionRunAction(actionName, runParams), recordName)
 			if err != nil {
 				log.Fatalf("failed to create action run: %v", err)
 			}
@@ -115,4 +117,13 @@ func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 	cmd.MarkFlagsMutuallyExclusive("skip-params", "param")
 
 	return cmd
+}
+
+func newActionRunAction(actionName *name.Action, parameters map[string]string) *openv1alpha1resource.Action {
+	return &openv1alpha1resource.Action{
+		Name: actionName.String(),
+		Spec: &openv1alpha1commons.ActionSpec{
+			Parameters: parameters,
+		},
+	}
 }

--- a/pkg/cmd/action/run.go
+++ b/pkg/cmd/action/run.go
@@ -41,6 +41,7 @@ func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 	cmd := &cobra.Command{
 		Use:                   "run <action-resource-name/id> <record-resource-name/id> [-p <working-project-slug>] [-P <key1=value1>...] [--skip-params] [-f]",
 		Short:                 "Create an action run.",
+		Args:                  cobra.ExactArgs(2),
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.

--- a/pkg/cmd/action/run_test.go
+++ b/pkg/cmd/action/run_test.go
@@ -9,6 +9,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewRunCommandValidatesArgs(t *testing.T) {
+	cfgPath := ""
+	cmd := NewRunCommand(&cfgPath, nil, nil)
+	require.NotNil(t, cmd.Args)
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{name: "no arguments", wantErr: true},
+		{name: "only action", args: []string{"action"}, wantErr: true},
+		{name: "action and record", args: []string{"action", "record"}},
+		{name: "too many arguments", args: []string{"action", "record", "extra"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := cmd.Args(cmd, tt.args)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func TestNewActionRunAction(t *testing.T) {
 	action := &openv1alpha1resource.Action{
 		Name: "projects/p1/actions/a1",

--- a/pkg/cmd/action/run_test.go
+++ b/pkg/cmd/action/run_test.go
@@ -37,6 +37,32 @@ func TestNewRunCommandValidatesArgs(t *testing.T) {
 	}
 }
 
+func TestPromptActionRunParameters(t *testing.T) {
+	defaults := map[string]string{
+		"accessKey": "********",
+		"region":    "cn",
+	}
+
+	t.Run("unchanged values are omitted", func(t *testing.T) {
+		overrides := promptActionRunParameters(defaults, func(_ string, defaultValue string) string {
+			return defaultValue
+		})
+
+		assert.Empty(t, overrides)
+	})
+
+	t.Run("changed values are submitted", func(t *testing.T) {
+		overrides := promptActionRunParameters(defaults, func(_ string, defaultValue string) string {
+			if defaultValue == "********" {
+				return "new-access-key"
+			}
+			return defaultValue
+		})
+
+		assert.Equal(t, map[string]string{"accessKey": "new-access-key"}, overrides)
+	})
+}
+
 func TestNewActionRunAction(t *testing.T) {
 	action := &openv1alpha1resource.Action{
 		Name: "projects/p1/actions/a1",

--- a/pkg/cmd/action/run_test.go
+++ b/pkg/cmd/action/run_test.go
@@ -3,27 +3,45 @@ package action
 import (
 	"testing"
 
-	"github.com/coscene-io/cocli/internal/name"
+	openv1alpha1commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewActionRunAction(t *testing.T) {
-	actionName := &name.Action{ProjectID: "p1", ID: "a1"}
+	action := &openv1alpha1resource.Action{
+		Name: "projects/p1/actions/a1",
+		Spec: &openv1alpha1commons.ActionSpec{
+			Name:        "server-action",
+			Description: "server-description",
+			Parameters:  map[string]string{"accessKey": "masked-default", "region": "cn"},
+			Jobs: []*openv1alpha1commons.JobSpec{{
+				Name: "main",
+			}},
+		},
+	}
 
-	t.Run("omitted overrides leave parameters empty for server defaults", func(t *testing.T) {
-		action := newActionRunAction(actionName, nil)
+	t.Run("omitted overrides preserve the action and leave parameters empty", func(t *testing.T) {
+		runAction := newActionRunAction(action, nil)
 
-		assert.Equal(t, "projects/p1/actions/a1", action.Name)
-		assert.Empty(t, action.Spec.Parameters)
-		assert.Empty(t, action.Spec.Jobs)
+		assert.Equal(t, "projects/p1/actions/a1", runAction.Name)
+		assert.Equal(t, "server-action", runAction.Spec.Name)
+		assert.Equal(t, "server-description", runAction.Spec.Description)
+		require.Len(t, runAction.Spec.Jobs, 1)
+		assert.Equal(t, "main", runAction.Spec.Jobs[0].Name)
+		assert.Empty(t, runAction.Spec.Parameters)
+		assert.Equal(t, "masked-default", action.Spec.Parameters["accessKey"])
 	})
 
-	t.Run("explicit overrides are the only submitted parameters", func(t *testing.T) {
+	t.Run("explicit overrides replace submitted parameters only", func(t *testing.T) {
 		overrides := map[string]string{"accessKey": "explicit-value"}
 
-		action := newActionRunAction(actionName, overrides)
+		runAction := newActionRunAction(action, overrides)
 
-		assert.Equal(t, overrides, action.Spec.Parameters)
-		assert.Empty(t, action.Spec.Jobs)
+		assert.Equal(t, overrides, runAction.Spec.Parameters)
+		require.Len(t, runAction.Spec.Jobs, 1)
+		assert.Equal(t, "main", runAction.Spec.Jobs[0].Name)
+		assert.Equal(t, map[string]string{"accessKey": "masked-default", "region": "cn"}, action.Spec.Parameters)
 	})
 }

--- a/pkg/cmd/action/run_test.go
+++ b/pkg/cmd/action/run_test.go
@@ -1,0 +1,29 @@
+package action
+
+import (
+	"testing"
+
+	"github.com/coscene-io/cocli/internal/name"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewActionRunAction(t *testing.T) {
+	actionName := &name.Action{ProjectID: "p1", ID: "a1"}
+
+	t.Run("omitted overrides leave parameters empty for server defaults", func(t *testing.T) {
+		action := newActionRunAction(actionName, nil)
+
+		assert.Equal(t, "projects/p1/actions/a1", action.Name)
+		assert.Empty(t, action.Spec.Parameters)
+		assert.Empty(t, action.Spec.Jobs)
+	})
+
+	t.Run("explicit overrides are the only submitted parameters", func(t *testing.T) {
+		overrides := map[string]string{"accessKey": "explicit-value"}
+
+		action := newActionRunAction(actionName, overrides)
+
+		assert.Equal(t, overrides, action.Spec.Parameters)
+		assert.Empty(t, action.Spec.Jobs)
+	})
+}


### PR DESCRIPTION
## Summary

`cocli action run` now fetches and submits the complete Action so jobs, quota, labels, mounts, and other Action fields remain part of the ActionRun request.

Before submission, cocli replaces `spec.parameters` with only the values supplied for this run. `--skip-params` submits no parameter overrides, allowing Matrix to apply stored defaults without copying masked values such as `accessKey=********`. Explicit `-P` values contain only the keys supplied by the user, while the interactive path continues to prompt from fetched defaults.

Deploy Matrix PR [coscene-io/matrix#798](https://github.com/coscene-io/matrix/pull/798) before releasing this change.

Related: coscene-io/matrix#798

## Validation

- `go test ./... -count=1`
- `go vet ./pkg/cmd/action ./api`
- `make build-binary`
- Regression coverage verifies complete Action fields are preserved, omitted overrides are empty, explicit parameters replace only the submitted parameter map, and the fetched Action is not mutated.

## Post-Deploy Monitoring & Validation

- Run one Action with `--skip-params` and one with `-P accessKey=<value>` against the same Action definition.
- Healthy signal: both ActionRuns reach `SUCCEEDED`; logs show the stored default for the skipped run and the explicit value for the override run.
- Watch cocli errors for `failed to get action` and `failed to create action run`.
- Roll back if `--skip-params` submits masked placeholders, or if ActionRuns lose jobs/spec fields.
- Validation window: first 30 minutes after release; owner: cocli releaser.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
