### PR TITLE
feat(action): add action run cancellation

### DIFF
--- a/api/action.go
+++ b/api/action.go
@@ -52,6 +52,9 @@ type ActionInterface interface {
 	// CreateActionRun creates an action run.
 	CreateActionRun(ctx context.Context, action *openv1alpha1resource.Action, record *name.Record) error
 
+	// TerminateActionRun requests termination of an action run.
+	TerminateActionRun(ctx context.Context, actionRun *name.ActionRun) error
+
 	// ListAllActionRuns lists all action runs in the current organization.
 	ListAllActionRuns(ctx context.Context, listOpts *ListActionRunsOptions) ([]*openv1alpha1resource.ActionRun, error)
 
@@ -185,6 +188,18 @@ func (c *actionClient) CreateActionRun(ctx context.Context, action *openv1alpha1
 	_, err := c.actionRunServiceClient.CreateActionRun(ctx, req)
 	if err != nil {
 		return fmt.Errorf("failed to create action run: %w", err)
+	}
+
+	return nil
+}
+
+func (c *actionClient) TerminateActionRun(ctx context.Context, actionRun *name.ActionRun) error {
+	req := connect.NewRequest(&openv1alpha1service.TerminateActionRunRequest{
+		Name: actionRun.String(),
+	})
+	_, err := c.actionRunServiceClient.TerminateActionRun(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to terminate action run: %w", err)
 	}
 
 	return nil

--- a/api/action_test.go
+++ b/api/action_test.go
@@ -83,8 +83,9 @@ type mockActionRunServiceClient struct {
 	openv1alpha1connect.ActionRunServiceClient
 	ctrl *gomock.Controller
 
-	createActionRunFunc func(context.Context, *connect.Request[openv1alpha1service.CreateActionRunRequest]) (*connect.Response[openv1alpha1resource.ActionRun], error)
-	listActionRunsFunc  func(context.Context, *connect.Request[openv1alpha1service.ListActionRunsRequest]) (*connect.Response[openv1alpha1service.ListActionRunsResponse], error)
+	createActionRunFunc    func(context.Context, *connect.Request[openv1alpha1service.CreateActionRunRequest]) (*connect.Response[openv1alpha1resource.ActionRun], error)
+	listActionRunsFunc     func(context.Context, *connect.Request[openv1alpha1service.ListActionRunsRequest]) (*connect.Response[openv1alpha1service.ListActionRunsResponse], error)
+	terminateActionRunFunc func(context.Context, *connect.Request[openv1alpha1service.TerminateActionRunRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
 func (m *mockActionRunServiceClient) CreateActionRun(ctx context.Context, req *connect.Request[openv1alpha1service.CreateActionRunRequest]) (*connect.Response[openv1alpha1resource.ActionRun], error) {
@@ -97,6 +98,13 @@ func (m *mockActionRunServiceClient) CreateActionRun(ctx context.Context, req *c
 func (m *mockActionRunServiceClient) ListActionRuns(ctx context.Context, req *connect.Request[openv1alpha1service.ListActionRunsRequest]) (*connect.Response[openv1alpha1service.ListActionRunsResponse], error) {
 	if m.listActionRunsFunc != nil {
 		return m.listActionRunsFunc(ctx, req)
+	}
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+
+func (m *mockActionRunServiceClient) TerminateActionRun(ctx context.Context, req *connect.Request[openv1alpha1service.TerminateActionRunRequest]) (*connect.Response[emptypb.Empty], error) {
+	if m.terminateActionRunFunc != nil {
+		return m.terminateActionRunFunc(ctx, req)
 	}
 	return nil, connect.NewError(connect.CodeUnimplemented, nil)
 }
@@ -293,6 +301,39 @@ func TestActionClient_CreateActionRun(t *testing.T) {
 		client := NewActionClient(nil, mockRun)
 		err := client.CreateActionRun(ctx, &openv1alpha1resource.Action{}, &name.Record{ProjectID: "p1", RecordID: "r1"})
 		assert.Error(t, err)
+	})
+}
+
+func TestActionClient_TerminateActionRun(t *testing.T) {
+	ctx := testutil.TestContext(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	actionRun := &name.ActionRun{ProjectID: "p1", ID: "r1"}
+
+	t.Run("success sends the full action run name", func(t *testing.T) {
+		mockRun := &mockActionRunServiceClient{
+			ctrl: ctrl,
+			terminateActionRunFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.TerminateActionRunRequest]) (*connect.Response[emptypb.Empty], error) {
+				assert.Equal(t, "projects/p1/actionRuns/r1", req.Msg.Name)
+				return connect.NewResponse(&emptypb.Empty{}), nil
+			},
+		}
+		client := NewActionClient(nil, mockRun)
+		err := client.TerminateActionRun(ctx, actionRun)
+		require.NoError(t, err)
+	})
+
+	t.Run("error is wrapped preserving connect code", func(t *testing.T) {
+		mockRun := &mockActionRunServiceClient{
+			ctrl: ctrl,
+			terminateActionRunFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.TerminateActionRunRequest]) (*connect.Response[emptypb.Empty], error) {
+				return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("already finished"))
+			},
+		}
+		client := NewActionClient(nil, mockRun)
+		err := client.TerminateActionRun(ctx, actionRun)
+		require.Error(t, err)
+		assert.True(t, utils.IsConnectErrorWithCode(err, connect.CodeInvalidArgument))
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/coscene-io/cocli
 go 1.25.0
 
 require (
-	buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260709002126-f5ec6f481038.1
-	buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260709002126-f5ec6f481038.1
+	buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260722064545-3ab95d97d4cc.1
+	buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260722064545-3ab95d97d4cc.1
 	connectrpc.com/connect v1.20.0
 	dario.cat/mergo v1.0.2
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20240508200655-46a4cf4ba109.1 h1:NXwdBG3BiC6xWH4iG3csbT+JHF9u1jl5ThDhumCnKnk=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20240508200655-46a4cf4ba109.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
-buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260709002126-f5ec6f481038.1 h1:GcMHBF5E8rDLiOjEjGYKciBr/69WT5lJ23vc87lPe8I=
-buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260709002126-f5ec6f481038.1/go.mod h1:9k72p7X+thAVEAa+/B1+SwZAEp19tEBRDq2dJvs+zbw=
-buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260709002126-f5ec6f481038.1 h1:VuRd112Wc13WDGrKHVYnOguGnv3ajn0WCltTlk/9YOc=
-buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260709002126-f5ec6f481038.1/go.mod h1:ncUQjVNWzogYkhgQ1XinFjWE1h7HuPtKpimyf90abE0=
+buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260722064545-3ab95d97d4cc.1 h1:YWIBXMCkMVpUo741yX5FyhHR5xstii2eWqMxmkCFelg=
+buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260722064545-3ab95d97d4cc.1/go.mod h1:zjgaxHuXv3y4+qODmZUjh2N9GVfjcBb6xC8JakjuRDw=
+buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260722064545-3ab95d97d4cc.1 h1:dOOlDYQMv4FWTsSbgnIJo5hK7z9uEdWfOHoydHKVb58=
+buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260722064545-3ab95d97d4cc.1/go.mod h1:ncUQjVNWzogYkhgQ1XinFjWE1h7HuPtKpimyf90abE0=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.11-20230414000709-087bc8072ce4.1 h1:t8f+WWZ5WNrZaP5zrpWD8f1tKU7eelJMbIAT9FRX558=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.11-20230414000709-087bc8072ce4.1/go.mod h1:/t9AeRQQp2iNkiGHDLfHLW3SzNpYpNPGRZ+Ih8+SOUs=
 connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=

--- a/pkg/cmd/action/action_run.go
+++ b/pkg/cmd/action/action_run.go
@@ -1,0 +1,32 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"fmt"
+
+	"github.com/coscene-io/cocli/internal/name"
+)
+
+// resolveActionRun accepts a full action-run resource name or a bare UUID.
+func resolveActionRun(arg string, proj *name.Project) (*name.ActionRun, error) {
+	if actionRun, err := name.NewActionRun(arg); err == nil {
+		return actionRun, nil
+	}
+	if name.IsUUID(arg) {
+		return &name.ActionRun{ProjectID: proj.ProjectID, ID: arg}, nil
+	}
+	return nil, fmt.Errorf("invalid action run name or id: %s", arg)
+}

--- a/pkg/cmd/action/action_test.go
+++ b/pkg/cmd/action/action_test.go
@@ -43,7 +43,7 @@ func TestActionCommand(t *testing.T) {
 		assert.Equal(t, "action", cmd.Use)
 		assert.NotEmpty(t, cmd.Short)
 
-		expectedSubcommands := []string{"create", "get", "update", "delete", "list", "list-run", "logs", "run"}
+		expectedSubcommands := []string{"create", "get", "update", "delete", "list", "list-run", "logs", "run", "cancel-run"}
 
 		for _, expected := range expectedSubcommands {
 			found := false

--- a/pkg/cmd/action/cancel_run.go
+++ b/pkg/cmd/action/cancel_run.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"fmt"
 
+	openv1alpha1enums "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/enums"
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"github.com/coscene-io/cocli/api"
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/name"
@@ -28,7 +31,8 @@ import (
 
 const cancelRunConfirmation = "Request cancellation for this action run? This cannot be undone."
 
-type actionRunTerminator interface {
+type actionRunCanceler interface {
+	ListAllActionRuns(context.Context, *api.ListActionRunsOptions) ([]*openv1alpha1resource.ActionRun, error)
 	TerminateActionRun(context.Context, *name.ActionRun) error
 }
 
@@ -65,7 +69,7 @@ func NewCancelRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider f
 	return cmd
 }
 
-func cancelActionRun(ctx context.Context, io *iostreams.IOStreams, cli actionRunTerminator, actionRunRef string, proj *name.Project, force bool, confirm confirmCancelRun) error {
+func cancelActionRun(ctx context.Context, io *iostreams.IOStreams, cli actionRunCanceler, actionRunRef string, proj *name.Project, force bool, confirm confirmCancelRun) error {
 	actionRun, err := resolveActionRun(actionRunRef, proj)
 	if err != nil {
 		return err
@@ -76,10 +80,46 @@ func cancelActionRun(ctx context.Context, io *iostreams.IOStreams, cli actionRun
 		return nil
 	}
 
+	runs, err := cli.ListAllActionRuns(ctx, &api.ListActionRunsOptions{
+		Parent: actionRun.Project().String(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to check action run state: %w", err)
+	}
+
+	run := findActionRun(runs, actionRun.String())
+	if run == nil {
+		return fmt.Errorf("action run not found: %s", actionRun)
+	}
+	if isFinishedActionRun(run.GetState()) {
+		io.Printf("Action run has already finished with state %s. No cancellation request was sent.\n", run.GetState())
+		return nil
+	}
+
 	if err = cli.TerminateActionRun(ctx, actionRun); err != nil {
 		return fmt.Errorf("failed to request action run cancellation: %w", err)
 	}
 
 	io.Println("Action run cancellation requested successfully.")
 	return nil
+}
+
+func findActionRun(runs []*openv1alpha1resource.ActionRun, target string) *openv1alpha1resource.ActionRun {
+	for _, run := range runs {
+		if run.GetName() == target {
+			return run
+		}
+	}
+	return nil
+}
+
+func isFinishedActionRun(state openv1alpha1enums.ActionRunStateEnum_ActionRunState) bool {
+	switch state {
+	case openv1alpha1enums.ActionRunStateEnum_SUCCEEDED,
+		openv1alpha1enums.ActionRunStateEnum_FAILED,
+		openv1alpha1enums.ActionRunStateEnum_ABORTED:
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/cmd/action/cancel_run.go
+++ b/pkg/cmd/action/cancel_run.go
@@ -1,0 +1,82 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/internal/name"
+	"github.com/coscene-io/cocli/internal/prompts"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
+	"github.com/spf13/cobra"
+)
+
+const cancelRunConfirmation = "Request cancellation for this action run? This cannot be undone."
+
+type actionRunTerminator interface {
+	TerminateActionRun(context.Context, *name.ActionRun) error
+}
+
+type confirmCancelRun func(string, *iostreams.IOStreams) bool
+
+func NewCancelRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(string) config.Provider) *cobra.Command {
+	var (
+		force       bool
+		projectSlug string
+	)
+
+	cmd := &cobra.Command{
+		Use:                   "cancel-run <action-run-name/id> [-p <working-project-slug>] [-f]",
+		Short:                 "Request cancellation of an action run.",
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
+			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
+			if err != nil {
+				return fmt.Errorf("unable to get project name: %w", err)
+			}
+
+			return cancelActionRun(cmd.Context(), io, pm.ActionCli(), args[0], proj, force, prompts.PromptYN)
+		},
+	}
+
+	cmd.Flags().StringVarP(&projectSlug, "project", "p", "", "the slug of the working project")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "request cancellation without confirmation")
+
+	return cmd
+}
+
+func cancelActionRun(ctx context.Context, io *iostreams.IOStreams, cli actionRunTerminator, actionRunRef string, proj *name.Project, force bool, confirm confirmCancelRun) error {
+	actionRun, err := resolveActionRun(actionRunRef, proj)
+	if err != nil {
+		return err
+	}
+
+	if !force && !confirm(cancelRunConfirmation, io) {
+		io.Println("Action run cancellation aborted.")
+		return nil
+	}
+
+	if err = cli.TerminateActionRun(ctx, actionRun); err != nil {
+		return fmt.Errorf("failed to request action run cancellation: %w", err)
+	}
+
+	io.Println("Action run cancellation requested successfully.")
+	return nil
+}

--- a/pkg/cmd/action/cancel_run.go
+++ b/pkg/cmd/action/cancel_run.go
@@ -46,6 +46,9 @@ func NewCancelRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider f
 		DisableFlagsInUseLine: true,
 		Args:                  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+
 			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
 			proj, err := pm.ProjectName(cmd.Context(), projectSlug)
 			if err != nil {

--- a/pkg/cmd/action/cancel_run_test.go
+++ b/pkg/cmd/action/cancel_run_test.go
@@ -20,7 +20,10 @@ import (
 	"errors"
 	"testing"
 
+	openv1alpha1enums "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/enums"
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
 	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/api"
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/name"
@@ -29,12 +32,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type fakeActionRunTerminator struct {
-	got *name.ActionRun
-	err error
+const cancelRunTestID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+type fakeActionRunCanceler struct {
+	runs       []*openv1alpha1resource.ActionRun
+	listErr    error
+	listCalled bool
+	got        *name.ActionRun
+	err        error
 }
 
-func (f *fakeActionRunTerminator) TerminateActionRun(_ context.Context, actionRun *name.ActionRun) error {
+func (f *fakeActionRunCanceler) ListAllActionRuns(_ context.Context, opts *api.ListActionRunsOptions) ([]*openv1alpha1resource.ActionRun, error) {
+	f.listCalled = true
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if f.runs != nil {
+		return f.runs, nil
+	}
+	return []*openv1alpha1resource.ActionRun{{
+		Name:  opts.Parent + "/actionRuns/" + cancelRunTestID,
+		State: openv1alpha1enums.ActionRunStateEnum_RUNNING,
+	}}, nil
+}
+
+func (f *fakeActionRunCanceler) TerminateActionRun(_ context.Context, actionRun *name.ActionRun) error {
 	f.got = actionRun
 	return f.err
 }
@@ -92,70 +114,119 @@ func TestCancelRunArgumentErrorPrintsUsage(t *testing.T) {
 }
 
 func TestCancelActionRunResolvesFullName(t *testing.T) {
-	cli := &fakeActionRunTerminator{}
+	cli := &fakeActionRunCanceler{}
 	io, out := cancelRunTestIO()
 	proj := &name.Project{ProjectID: "11111111-1111-1111-1111-111111111111"}
 
-	err := cancelActionRun(context.Background(), io, cli, "projects/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/actionRuns/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", proj, true, failIfConfirmed(t))
+	err := cancelActionRun(context.Background(), io, cli, "projects/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/actionRuns/"+cancelRunTestID, proj, true, failIfConfirmed(t))
 	require.NoError(t, err)
 	require.NotNil(t, cli.got)
 	assert.Equal(t, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", cli.got.ProjectID)
-	assert.Equal(t, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", cli.got.ID)
+	assert.Equal(t, cancelRunTestID, cli.got.ID)
 	assert.Contains(t, out.String(), "Action run cancellation requested successfully.")
 }
 
 func TestCancelActionRunResolvesBareUUIDWithProject(t *testing.T) {
-	cli := &fakeActionRunTerminator{}
+	cli := &fakeActionRunCanceler{}
 	io, _ := cancelRunTestIO()
 	proj := &name.Project{ProjectID: "11111111-1111-1111-1111-111111111111"}
 
-	err := cancelActionRun(context.Background(), io, cli, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", proj, true, failIfConfirmed(t))
+	err := cancelActionRun(context.Background(), io, cli, cancelRunTestID, proj, true, failIfConfirmed(t))
 	require.NoError(t, err)
 	require.NotNil(t, cli.got)
 	assert.Equal(t, proj.ProjectID, cli.got.ProjectID)
 }
 
 func TestCancelActionRunRefusalDoesNotCallAPI(t *testing.T) {
-	cli := &fakeActionRunTerminator{}
+	cli := &fakeActionRunCanceler{}
 	io, out := cancelRunTestIO()
 	confirmed := false
 
-	err := cancelActionRun(context.Background(), io, cli, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", &name.Project{ProjectID: "p1"}, false, func(prompt string, _ *iostreams.IOStreams) bool {
+	err := cancelActionRun(context.Background(), io, cli, cancelRunTestID, &name.Project{ProjectID: "p1"}, false, func(prompt string, _ *iostreams.IOStreams) bool {
 		confirmed = true
 		assert.Contains(t, prompt, "cannot be undone")
 		return false
 	})
 	require.NoError(t, err)
 	assert.True(t, confirmed)
+	assert.False(t, cli.listCalled)
 	assert.Nil(t, cli.got)
 	assert.Contains(t, out.String(), "Action run cancellation aborted.")
 }
 
 func TestCancelActionRunForceSkipsConfirmation(t *testing.T) {
-	cli := &fakeActionRunTerminator{}
+	cli := &fakeActionRunCanceler{}
 	io, _ := cancelRunTestIO()
 
-	err := cancelActionRun(context.Background(), io, cli, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", &name.Project{ProjectID: "p1"}, true, failIfConfirmed(t))
+	err := cancelActionRun(context.Background(), io, cli, cancelRunTestID, &name.Project{ProjectID: "p1"}, true, failIfConfirmed(t))
 	require.NoError(t, err)
+	assert.True(t, cli.listCalled)
 	assert.NotNil(t, cli.got)
 }
 
 func TestCancelActionRunRejectsInvalidReference(t *testing.T) {
-	cli := &fakeActionRunTerminator{}
+	cli := &fakeActionRunCanceler{}
 	io, _ := cancelRunTestIO()
 
 	err := cancelActionRun(context.Background(), io, cli, "invalid", &name.Project{ProjectID: "p1"}, true, failIfConfirmed(t))
 	require.Error(t, err)
+	assert.False(t, cli.listCalled)
 	assert.Nil(t, cli.got)
 }
 
 func TestCancelActionRunPreservesConnectErrorCode(t *testing.T) {
-	cli := &fakeActionRunTerminator{err: connect.NewError(connect.CodeInvalidArgument, errors.New("already finished"))}
+	cli := &fakeActionRunCanceler{err: connect.NewError(connect.CodeInvalidArgument, errors.New("already finished"))}
 	io, _ := cancelRunTestIO()
 
-	err := cancelActionRun(context.Background(), io, cli, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", &name.Project{ProjectID: "p1"}, true, failIfConfirmed(t))
+	err := cancelActionRun(context.Background(), io, cli, cancelRunTestID, &name.Project{ProjectID: "p1"}, true, failIfConfirmed(t))
 	require.Error(t, err)
 	assert.True(t, utils.IsConnectErrorWithCode(err, connect.CodeInvalidArgument))
+}
+
+func TestCancelActionRunFinishedDoesNotRequestCancellation(t *testing.T) {
+	tests := []struct {
+		name  string
+		state openv1alpha1enums.ActionRunStateEnum_ActionRunState
+	}{
+		{name: "succeeded", state: openv1alpha1enums.ActionRunStateEnum_SUCCEEDED},
+		{name: "failed", state: openv1alpha1enums.ActionRunStateEnum_FAILED},
+		{name: "aborted", state: openv1alpha1enums.ActionRunStateEnum_ABORTED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := &fakeActionRunCanceler{runs: []*openv1alpha1resource.ActionRun{{
+				Name:  "projects/p1/actionRuns/" + cancelRunTestID,
+				State: tt.state,
+			}}}
+			io, out := cancelRunTestIO()
+
+			err := cancelActionRun(context.Background(), io, cli, cancelRunTestID, &name.Project{ProjectID: "p1"}, true, failIfConfirmed(t))
+			require.NoError(t, err)
+			assert.Nil(t, cli.got)
+			assert.Contains(t, out.String(), "Action run has already finished with state "+tt.state.String())
+			assert.Contains(t, out.String(), "No cancellation request was sent.")
+		})
+	}
+}
+
+func TestCancelActionRunNotFoundDoesNotRequestCancellation(t *testing.T) {
+	cli := &fakeActionRunCanceler{runs: []*openv1alpha1resource.ActionRun{}}
+	io, _ := cancelRunTestIO()
+
+	err := cancelActionRun(context.Background(), io, cli, cancelRunTestID, &name.Project{ProjectID: "p1"}, true, failIfConfirmed(t))
+	require.EqualError(t, err, "action run not found: projects/p1/actionRuns/"+cancelRunTestID)
+	assert.Nil(t, cli.got)
+}
+
+func TestCancelActionRunStateCheckPreservesConnectErrorCode(t *testing.T) {
+	cli := &fakeActionRunCanceler{listErr: connect.NewError(connect.CodePermissionDenied, errors.New("denied"))}
+	io, _ := cancelRunTestIO()
+
+	err := cancelActionRun(context.Background(), io, cli, cancelRunTestID, &name.Project{ProjectID: "p1"}, true, failIfConfirmed(t))
+	require.Error(t, err)
+	assert.True(t, utils.IsConnectErrorWithCode(err, connect.CodePermissionDenied))
+	assert.Nil(t, cli.got)
 }
 
 func cancelRunTestIO() (*iostreams.IOStreams, *bytes.Buffer) {

--- a/pkg/cmd/action/cancel_run_test.go
+++ b/pkg/cmd/action/cancel_run_test.go
@@ -57,6 +57,40 @@ func TestCancelRunCommandRegistrationAndFlags(t *testing.T) {
 	assert.Error(t, cancelCmd.Args(cancelCmd, []string{"run", "extra"}))
 }
 
+func TestCancelRunRuntimeErrorDoesNotPrintUsage(t *testing.T) {
+	cfgPath := setupActionCmdTestConfigPath(t)
+	var out bytes.Buffer
+	io := iostreams.Test(nil, &out, &out)
+	cmd := NewCancelRunCommand(&cfgPath, io, nil)
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetContext(config.ContextWithProfileManager(context.Background(), &config.ProfileManager{
+		CurrentProfile: "test",
+		Profiles: []*config.Profile{{
+			Name: "test",
+		}},
+	}))
+	cmd.SetArgs([]string{"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "--force"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.NotContains(t, out.String(), "Usage:")
+	assert.NotContains(t, out.String(), "Error:")
+}
+
+func TestCancelRunArgumentErrorPrintsUsage(t *testing.T) {
+	cfgPath := setupActionCmdTestConfigPath(t)
+	var out bytes.Buffer
+	io := iostreams.Test(nil, &out, &out)
+	cmd := NewCancelRunCommand(&cfgPath, io, nil)
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, out.String(), "Usage:")
+}
+
 func TestCancelActionRunResolvesFullName(t *testing.T) {
 	cli := &fakeActionRunTerminator{}
 	io, out := cancelRunTestIO()

--- a/pkg/cmd/action/cancel_run_test.go
+++ b/pkg/cmd/action/cancel_run_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package action
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/internal/name"
+	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeActionRunTerminator struct {
+	got *name.ActionRun
+	err error
+}
+
+func (f *fakeActionRunTerminator) TerminateActionRun(_ context.Context, actionRun *name.ActionRun) error {
+	f.got = actionRun
+	return f.err
+}
+
+func TestCancelRunCommandRegistrationAndFlags(t *testing.T) {
+	cfgPath := setupActionCmdTestConfigPath(t)
+	var out bytes.Buffer
+	io := iostreams.Test(nil, &out, &out)
+	cmd := NewRootCommand(&cfgPath, io, config.Provide)
+
+	cancelCmd, _, err := cmd.Find([]string{"cancel-run"})
+	require.NoError(t, err)
+	assert.Equal(t, "cancel-run", cancelCmd.Name())
+	assert.NotNil(t, cancelCmd.Flag("project"))
+	assert.Equal(t, "p", cancelCmd.Flag("project").Shorthand)
+	assert.NotNil(t, cancelCmd.Flag("force"))
+	assert.Equal(t, "f", cancelCmd.Flag("force").Shorthand)
+	assert.Error(t, cancelCmd.Args(cancelCmd, nil))
+	assert.NoError(t, cancelCmd.Args(cancelCmd, []string{"run"}))
+	assert.Error(t, cancelCmd.Args(cancelCmd, []string{"run", "extra"}))
+}
+
+func TestCancelActionRunResolvesFullName(t *testing.T) {
+	cli := &fakeActionRunTerminator{}
+	io, out := cancelRunTestIO()
+	proj := &name.Project{ProjectID: "11111111-1111-1111-1111-111111111111"}
+
+	err := cancelActionRun(context.Background(), io, cli, "projects/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/actionRuns/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", proj, true, failIfConfirmed(t))
+	require.NoError(t, err)
+	require.NotNil(t, cli.got)
+	assert.Equal(t, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", cli.got.ProjectID)
+	assert.Equal(t, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", cli.got.ID)
+	assert.Contains(t, out.String(), "Action run cancellation requested successfully.")
+}
+
+func TestCancelActionRunResolvesBareUUIDWithProject(t *testing.T) {
+	cli := &fakeActionRunTerminator{}
+	io, _ := cancelRunTestIO()
+	proj := &name.Project{ProjectID: "11111111-1111-1111-1111-111111111111"}
+
+	err := cancelActionRun(context.Background(), io, cli, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", proj, true, failIfConfirmed(t))
+	require.NoError(t, err)
+	require.NotNil(t, cli.got)
+	assert.Equal(t, proj.ProjectID, cli.got.ProjectID)
+}
+
+func TestCancelActionRunRefusalDoesNotCallAPI(t *testing.T) {
+	cli := &fakeActionRunTerminator{}
+	io, out := cancelRunTestIO()
+	confirmed := false
+
+	err := cancelActionRun(context.Background(), io, cli, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", &name.Project{ProjectID: "p1"}, false, func(prompt string, _ *iostreams.IOStreams) bool {
+		confirmed = true
+		assert.Contains(t, prompt, "cannot be undone")
+		return false
+	})
+	require.NoError(t, err)
+	assert.True(t, confirmed)
+	assert.Nil(t, cli.got)
+	assert.Contains(t, out.String(), "Action run cancellation aborted.")
+}
+
+func TestCancelActionRunForceSkipsConfirmation(t *testing.T) {
+	cli := &fakeActionRunTerminator{}
+	io, _ := cancelRunTestIO()
+
+	err := cancelActionRun(context.Background(), io, cli, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", &name.Project{ProjectID: "p1"}, true, failIfConfirmed(t))
+	require.NoError(t, err)
+	assert.NotNil(t, cli.got)
+}
+
+func TestCancelActionRunRejectsInvalidReference(t *testing.T) {
+	cli := &fakeActionRunTerminator{}
+	io, _ := cancelRunTestIO()
+
+	err := cancelActionRun(context.Background(), io, cli, "invalid", &name.Project{ProjectID: "p1"}, true, failIfConfirmed(t))
+	require.Error(t, err)
+	assert.Nil(t, cli.got)
+}
+
+func TestCancelActionRunPreservesConnectErrorCode(t *testing.T) {
+	cli := &fakeActionRunTerminator{err: connect.NewError(connect.CodeInvalidArgument, errors.New("already finished"))}
+	io, _ := cancelRunTestIO()
+
+	err := cancelActionRun(context.Background(), io, cli, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", &name.Project{ProjectID: "p1"}, true, failIfConfirmed(t))
+	require.Error(t, err)
+	assert.True(t, utils.IsConnectErrorWithCode(err, connect.CodeInvalidArgument))
+}
+
+func cancelRunTestIO() (*iostreams.IOStreams, *bytes.Buffer) {
+	var out bytes.Buffer
+	return iostreams.Test(nil, &out, &out), &out
+}
+
+func failIfConfirmed(t *testing.T) confirmCancelRun {
+	t.Helper()
+	return func(string, *iostreams.IOStreams) bool {
+		t.Fatal("confirmation must be skipped")
+		return false
+	}
+}

--- a/pkg/cmd/action/logs.go
+++ b/pkg/cmd/action/logs.go
@@ -155,17 +155,6 @@ of whether the run is in progress or already completed.
 	return cmd
 }
 
-// resolveActionRun accepts a full action-run resource name or a bare UUID.
-func resolveActionRun(arg string, proj *name.Project) (*name.ActionRun, error) {
-	if actionRun, err := name.NewActionRun(arg); err == nil {
-		return actionRun, nil
-	}
-	if name.IsUUID(arg) {
-		return &name.ActionRun{ProjectID: proj.ProjectID, ID: arg}, nil
-	}
-	return nil, fmt.Errorf("invalid action run name or id: %s", arg)
-}
-
 // selectJobRun lists the action run's job runs and picks the requested index.
 // The index is 1-based (1 = first job run). Returns (nil, nil) when there is
 // nothing to stream and the situation has already been reported to the user

--- a/pkg/cmd/action/root.go
+++ b/pkg/cmd/action/root.go
@@ -27,6 +27,7 @@ func NewRootCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(s
 	}
 
 	cmd.AddCommand(NewCreateCommand(cfgPath, io, getProvider))
+	cmd.AddCommand(NewCancelRunCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewGetCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewUpdateCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewDeleteCommand(cfgPath, io, getProvider))


### PR DESCRIPTION
## Summary

- add `cocli action cancel-run <name-or-id> [-p <project>] [-f]`
- share ActionRun resolution between logs and cancellation for full names and bare UUIDs
- require confirmation by default, support `--force`, and preserve Connect error codes
- report successful submission as an asynchronous cancellation request

Related: coscene-io/coscene-openapi#73

## Testing

- `go test ./...`
- `go test -race -coverprofile=coverage.out -covermode=atomic ./...`

## Post-Deploy Monitoring & Validation

- after APIary and DPS are deployed, cancel a long-running ActionRun with `cancel-run -f`
- poll `action list-run` until the run reaches `ABORTED`
- confirm cancelling a completed run exits non-zero with `InvalidArgument`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coCLI/pr/190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787296659&installation_model_id=425002&pr_number=190&repository=coscene-io%2FcoCLI&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoCLI%2Fpull%2F190&signature=86e984963639d2fe0e8b53fa759283858d1973a7505856f420a43692405352ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->