### PR TITLE
feat(action): run actions with record queries

### DIFF
--- a/api/action.go
+++ b/api/action.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coscene-io/cocli/internal/name"
 	"github.com/samber/lo"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type ActionInterface interface {
@@ -51,6 +52,10 @@ type ActionInterface interface {
 
 	// CreateActionRun creates an action run.
 	CreateActionRun(ctx context.Context, action *openv1alpha1resource.Action, record *name.Record) error
+
+	// CreateActionRunWithRecordQuery creates an action run for records selected
+	// by a structured query.
+	CreateActionRunWithRecordQuery(ctx context.Context, action *openv1alpha1resource.Action, project *name.Project, recordQuery *structpb.Struct) error
 
 	// TerminateActionRun requests termination of an action run.
 	TerminateActionRun(ctx context.Context, actionRun *name.ActionRun) error
@@ -176,13 +181,45 @@ func (c *actionClient) DeleteAction(ctx context.Context, actionName *name.Action
 }
 
 func (c *actionClient) CreateActionRun(ctx context.Context, action *openv1alpha1resource.Action, record *name.Record) error {
+	return c.createActionRun(
+		ctx,
+		action,
+		record.Project().String(),
+		&openv1alpha1commons.TriggerMatch{Records: []string{record.String()}},
+	)
+}
+
+func (c *actionClient) CreateActionRunWithRecordQuery(
+	ctx context.Context,
+	action *openv1alpha1resource.Action,
+	project *name.Project,
+	recordQuery *structpb.Struct,
+) error {
+	if recordQuery == nil || len(recordQuery.GetFields()) == 0 {
+		return fmt.Errorf("record query must not be empty")
+	}
+
+	return c.createActionRun(
+		ctx,
+		action,
+		project.String(),
+		&openv1alpha1commons.TriggerMatch{
+			RecordQuery: recordQuery,
+		},
+	)
+}
+
+func (c *actionClient) createActionRun(
+	ctx context.Context,
+	action *openv1alpha1resource.Action,
+	parent string,
+	match *openv1alpha1commons.TriggerMatch,
+) error {
 	req := connect.NewRequest(&openv1alpha1service.CreateActionRunRequest{
-		Parent: record.Project().String(),
+		Parent: parent,
 		ActionRun: &openv1alpha1resource.ActionRun{
 			Action: action,
-			Match: &openv1alpha1commons.TriggerMatch{
-				Records: []string{record.String()},
-			},
+			Match:  match,
 		},
 	})
 	_, err := c.actionRunServiceClient.CreateActionRun(ctx, req)

--- a/api/action_test.go
+++ b/api/action_test.go
@@ -30,7 +30,9 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type mockActionServiceClient struct {
@@ -285,6 +287,8 @@ func TestActionClient_CreateActionRun(t *testing.T) {
 			createActionRunFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.CreateActionRunRequest]) (*connect.Response[openv1alpha1resource.ActionRun], error) {
 				assert.Equal(t, "projects/p1", req.Msg.Parent)
 				assert.Same(t, action, req.Msg.ActionRun.Action)
+				assert.Equal(t, []string{"projects/p1/records/r1"}, req.Msg.ActionRun.Match.Records)
+				assert.Nil(t, req.Msg.ActionRun.Match.RecordQuery)
 				return connect.NewResponse(&openv1alpha1resource.ActionRun{}), nil
 			},
 		}
@@ -336,6 +340,48 @@ func TestActionClient_TerminateActionRun(t *testing.T) {
 		err := client.TerminateActionRun(ctx, actionRun)
 		require.Error(t, err)
 		assert.True(t, utils.IsConnectErrorWithCode(err, connect.CodeInvalidArgument))
+	})
+}
+
+func TestActionClient_CreateActionRunWithRecordQuery(t *testing.T) {
+	ctx := testutil.TestContext(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("success", func(t *testing.T) {
+		action := &openv1alpha1resource.Action{Name: "projects/p1/actions/a1"}
+		recordQuery, err := structpb.NewStruct(map[string]any{
+			"==": []any{map[string]any{"var": "isArchived"}, "false"},
+		})
+		require.NoError(t, err)
+		mockRun := &mockActionRunServiceClient{
+			ctrl: ctrl,
+			createActionRunFunc: func(ctx context.Context, req *connect.Request[openv1alpha1service.CreateActionRunRequest]) (*connect.Response[openv1alpha1resource.ActionRun], error) {
+				assert.Equal(t, "projects/p1", req.Msg.Parent)
+				assert.Same(t, action, req.Msg.ActionRun.Action)
+				assert.Empty(t, req.Msg.ActionRun.Match.Records)
+				assert.True(t, proto.Equal(recordQuery, req.Msg.ActionRun.Match.RecordQuery))
+				return connect.NewResponse(&openv1alpha1resource.ActionRun{}), nil
+			},
+		}
+		client := NewActionClient(nil, mockRun)
+
+		err = client.CreateActionRunWithRecordQuery(ctx, action, &name.Project{ProjectID: "p1"}, recordQuery)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects empty query", func(t *testing.T) {
+		client := NewActionClient(nil, &mockActionRunServiceClient{ctrl: ctrl})
+
+		err := client.CreateActionRunWithRecordQuery(
+			ctx,
+			&openv1alpha1resource.Action{},
+			&name.Project{ProjectID: "p1"},
+			&structpb.Struct{},
+		)
+
+		assert.EqualError(t, err, "record query must not be empty")
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/coscene-io/cocli
 go 1.25.0
 
 require (
-	buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260722064545-3ab95d97d4cc.1
-	buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260722064545-3ab95d97d4cc.1
+	buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260729110633-6566fd75c241.1
+	buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260729110633-6566fd75c241.1
 	connectrpc.com/connect v1.20.0
 	dario.cat/mergo v1.0.2
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20240508200655-46a4cf4ba109.1 h1:NXwdBG3BiC6xWH4iG3csbT+JHF9u1jl5ThDhumCnKnk=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20240508200655-46a4cf4ba109.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
-buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260722064545-3ab95d97d4cc.1 h1:YWIBXMCkMVpUo741yX5FyhHR5xstii2eWqMxmkCFelg=
-buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260722064545-3ab95d97d4cc.1/go.mod h1:zjgaxHuXv3y4+qODmZUjh2N9GVfjcBb6xC8JakjuRDw=
-buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260722064545-3ab95d97d4cc.1 h1:dOOlDYQMv4FWTsSbgnIJo5hK7z9uEdWfOHoydHKVb58=
-buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260722064545-3ab95d97d4cc.1/go.mod h1:ncUQjVNWzogYkhgQ1XinFjWE1h7HuPtKpimyf90abE0=
+buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260729110633-6566fd75c241.1 h1:a/I+FzWeHel1a7tYYY5GzIArY8uYAVq773u3j8YBZlM=
+buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go v1.20.0-20260729110633-6566fd75c241.1/go.mod h1:S4d9iSYLwvSjwGO4MJEM+cW9Jz9wKDj8+ILsAB+okj8=
+buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260729110633-6566fd75c241.1 h1:F5L5mt3YMSbVER5JNnSfKGbsKKBUJtiQFRNTcBN9q+A=
+buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go v1.36.11-20260729110633-6566fd75c241.1/go.mod h1:ncUQjVNWzogYkhgQ1XinFjWE1h7HuPtKpimyf90abE0=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.11-20230414000709-087bc8072ce4.1 h1:t8f+WWZ5WNrZaP5zrpWD8f1tKU7eelJMbIAT9FRX558=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.11-20230414000709-087bc8072ce4.1/go.mod h1:/t9AeRQQp2iNkiGHDLfHLW3SzNpYpNPGRZ+Ih8+SOUs=
 connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=

--- a/pkg/cmd/action/action_test.go
+++ b/pkg/cmd/action/action_test.go
@@ -99,6 +99,8 @@ func TestActionCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.NotNil(t, runCmd.Flag("project"), "Flag --project not found")
+		assert.NotNil(t, runCmd.Flag("search"), "Flag --search not found")
+		assert.Equal(t, "s", runCmd.Flag("search").Shorthand)
 	})
 
 	t.Run("List-run command flags", func(t *testing.T) {

--- a/pkg/cmd/action/run.go
+++ b/pkg/cmd/action/run.go
@@ -16,32 +16,35 @@ package action
 
 import (
 	"fmt"
+	"strings"
 
 	openv1alpha1commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
 	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
-	"connectrpc.com/connect"
 	"github.com/coscene-io/cocli/internal/config"
 	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/internal/name"
 	"github.com/coscene-io/cocli/internal/prompts"
-	"github.com/coscene-io/cocli/internal/utils"
 	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(string) config.Provider) *cobra.Command {
 	var (
-		params      = map[string]string{}
-		skipParams  = false
-		force       = false
-		projectSlug = ""
+		params       = map[string]string{}
+		skipParams   = false
+		force        = false
+		projectSlug  = ""
+		recordSearch = ""
 	)
 
 	cmd := &cobra.Command{
-		Use:                   "run <action-resource-name/id> <record-resource-name/id> [-p <working-project-slug>] [-P <key1=value1>...] [--skip-params] [-f]",
+		Use:                   "run <action-resource-name/id> [record-resource-name/id] [--search <json-logic>] [-p <working-project-slug>] [-P <key1=value1>...] [--skip-params] [-f]",
 		Short:                 "Create an action run.",
-		Args:                  cobra.ExactArgs(2),
+		Args:                  validateRunArgs,
 		DisableFlagsInUseLine: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get current profile.
@@ -56,12 +59,15 @@ func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 			if err != nil {
 				log.Fatalf("failed to convert action id to name: %v", err)
 			}
-			recordName, err := pm.RecordCli().RecordId2Name(cmd.Context(), args[1], proj)
-			if utils.IsConnectErrorWithCode(err, connect.CodeNotFound) {
-				io.Printf("failed to find record: %s in project: %s\n", args[1], proj)
-				return
-			} else if err != nil {
-				log.Fatalf("failed to convert record id to name: %v", err)
+			var recordName *name.Record
+			var recordQuery *structpb.Struct
+			if len(args) == 2 {
+				recordName = recordNameFromArg(args[1], proj)
+			} else {
+				recordQuery, err = parseRecordSearch(recordSearch)
+				if err != nil {
+					log.Fatalf("failed to parse record search: %v", err)
+				}
 			}
 			act, err := pm.ActionCli().GetByName(cmd.Context(), actionName)
 			if err != nil {
@@ -96,7 +102,12 @@ func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 			}
 
 			// Create action run
-			err = pm.ActionCli().CreateActionRun(cmd.Context(), newActionRunAction(act, runParams), recordName)
+			runAction := newActionRunAction(act, runParams)
+			if recordName != nil {
+				err = pm.ActionCli().CreateActionRun(cmd.Context(), runAction, recordName)
+			} else {
+				err = pm.ActionCli().CreateActionRunWithRecordQuery(cmd.Context(), runAction, proj, recordQuery)
+			}
 			if err != nil {
 				log.Fatalf("failed to create action run: %v", err)
 			}
@@ -109,11 +120,65 @@ func NewRunCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(st
 	cmd.Flags().BoolVar(&skipParams, "skip-params", false, "skip parameter input and use default values")
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "force create action run without confirmation")
 	cmd.Flags().StringVarP(&projectSlug, "project", "p", "", "the slug of the working project")
+	cmd.Flags().StringVarP(&recordSearch, "search", "s", "", "JSON Logic search query selecting records for the action run")
 
-	_ = cmd.MarkFlagRequired("record")
 	cmd.MarkFlagsMutuallyExclusive("skip-params", "param")
 
 	return cmd
+}
+
+func validateRunArgs(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("requires an action argument")
+	}
+	if len(args) > 2 {
+		return fmt.Errorf("accepts at most 2 arguments, received %d", len(args))
+	}
+
+	recordSearch, err := cmd.Flags().GetString("search")
+	if err != nil {
+		return err
+	}
+	searchSet := cmd.Flags().Changed("search")
+	if searchSet && strings.TrimSpace(recordSearch) == "" {
+		return fmt.Errorf("search query must not be empty")
+	}
+	if len(args) == 1 && !searchSet {
+		return fmt.Errorf("requires a record argument or --search")
+	}
+	if len(args) == 2 && searchSet {
+		return fmt.Errorf("record argument and --search are mutually exclusive")
+	}
+	if searchSet {
+		if _, err := parseRecordSearch(recordSearch); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func parseRecordSearch(search string) (*structpb.Struct, error) {
+	recordQuery := &structpb.Struct{}
+	if err := protojson.Unmarshal([]byte(search), recordQuery); err != nil {
+		return nil, fmt.Errorf("invalid search JSON: %w", err)
+	}
+	if len(recordQuery.GetFields()) == 0 {
+		return nil, fmt.Errorf("search query must not be empty")
+	}
+	return recordQuery, nil
+}
+
+func recordNameFromArg(recordIDOrName string, project *name.Project) *name.Record {
+	recordName, err := name.NewRecord(recordIDOrName)
+	if err == nil {
+		return recordName
+	}
+
+	return &name.Record{
+		ProjectID: project.ProjectID,
+		RecordID:  recordIDOrName,
+	}
 }
 
 func promptActionRunParameters(defaults map[string]string, prompt func(string, string) string) map[string]string {

--- a/pkg/cmd/action/run_test.go
+++ b/pkg/cmd/action/run_test.go
@@ -5,6 +5,7 @@ import (
 
 	openv1alpha1commons "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/commons"
 	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"github.com/coscene-io/cocli/internal/name"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,26 +16,75 @@ func TestNewRunCommandValidatesArgs(t *testing.T) {
 	require.NotNil(t, cmd.Args)
 
 	tests := []struct {
-		name    string
-		args    []string
-		wantErr bool
+		name         string
+		args         []string
+		recordSearch string
+		setSearch    bool
+		wantErr      string
 	}{
-		{name: "no arguments", wantErr: true},
-		{name: "only action", args: []string{"action"}, wantErr: true},
+		{name: "no arguments", wantErr: "requires an action argument"},
+		{name: "only action", args: []string{"action"}, wantErr: "requires a record argument or --search"},
 		{name: "action and record", args: []string{"action", "record"}},
-		{name: "too many arguments", args: []string{"action", "record", "extra"}, wantErr: true},
+		{name: "action and search", args: []string{"action"}, recordSearch: `{"==":[{"var":"isArchived"},"false"]}`, setSearch: true},
+		{name: "record and search", args: []string{"action", "record"}, recordSearch: `{"==":[{"var":"isArchived"},"false"]}`, setSearch: true, wantErr: "mutually exclusive"},
+		{name: "blank search", args: []string{"action"}, recordSearch: "  ", setSearch: true, wantErr: "search query must not be empty"},
+		{name: "empty search with record", args: []string{"action", "record"}, setSearch: true, wantErr: "search query must not be empty"},
+		{name: "invalid search JSON", args: []string{"action"}, recordSearch: `{`, setSearch: true, wantErr: "invalid search JSON"},
+		{name: "empty search object", args: []string{"action"}, recordSearch: `{}`, setSearch: true, wantErr: "search query must not be empty"},
+		{name: "null search", args: []string{"action"}, recordSearch: `null`, setSearch: true, wantErr: "invalid search JSON"},
+		{name: "search array", args: []string{"action"}, recordSearch: `[]`, setSearch: true, wantErr: "invalid search JSON"},
+		{name: "too many arguments", args: []string{"action", "record", "extra"}, wantErr: "accepts at most 2 arguments"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewRunCommand(&cfgPath, nil, nil)
+			if tt.setSearch {
+				require.NoError(t, cmd.Flags().Set("search", tt.recordSearch))
+			}
 			err := cmd.Args(cmd, tt.args)
-			if tt.wantErr {
-				assert.Error(t, err)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func TestParseRecordSearch(t *testing.T) {
+	search := `{"and":[{"==":[{"var":"isArchived"},"false"]},{"and":[{"==":[{"var":"customFields.c68621ba-4f29-4da0-8108-d76f612d2dae"},"aede4062-7f1f-4ecf-b3b7-ab604579ff4a"]}]}]}`
+
+	recordQuery, err := parseRecordSearch(search)
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"and": []any{
+			map[string]any{"==": []any{map[string]any{"var": "isArchived"}, "false"}},
+			map[string]any{"and": []any{
+				map[string]any{"==": []any{
+					map[string]any{"var": "customFields.c68621ba-4f29-4da0-8108-d76f612d2dae"},
+					"aede4062-7f1f-4ecf-b3b7-ab604579ff4a",
+				}},
+			}},
+		},
+	}, recordQuery.AsMap())
+}
+
+func TestRecordNameFromArg(t *testing.T) {
+	project := &name.Project{ProjectID: "project-1"}
+
+	t.Run("bare record ID uses the working project", func(t *testing.T) {
+		recordName := recordNameFromArg("record-1", project)
+
+		assert.Equal(t, "projects/project-1/records/record-1", recordName.String())
+	})
+
+	t.Run("full record name preserves its project", func(t *testing.T) {
+		recordName := recordNameFromArg("projects/project-2/records/record-2", project)
+
+		assert.Equal(t, "projects/project-2/records/record-2", recordName.String())
+	})
 }
 
 func TestPromptActionRunParameters(t *testing.T) {


### PR DESCRIPTION
## Summary

`cocli action run` can now select records with a JSON Logic query through `--search`, matching the browser action workflow while preserving positional single-record runs. Record and search selection are mutually exclusive, invalid or empty queries fail locally, and valid searches are sent as structured `TriggerMatch.RecordQuery` values. The confirmation flow continues to summarize parameters without echoing the potentially long search expression.

## Validation

- `GOWORK=off go test ./...`
- `GOWORK=off go test -race ./...`
- Installed the worktree build and submitted the reported long JSON Logic query successfully against the dev profile.
- Re-ran the dev command and aborted at confirmation to verify the search expression is no longer printed.

## Related

Related: coscene-io/apiary#87

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coCLI/pr/191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788000064&installation_model_id=425002&pr_number=191&repository=coscene-io%2FcoCLI&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoCLI%2Fpull%2F191&signature=58267a67ec38d807dc75361d26168c6305e09a568a3a05394b960a3ee4830725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->