### PR TITLE
feat: enforce compliant outbound TLS policy

### DIFF
--- a/api/api_utils/connect_client.go
+++ b/api/api_utils/connect_client.go
@@ -19,12 +19,14 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/internal/tlsconfig"
 	"golang.org/x/net/http2"
 )
 
 func NewConnectClient() connect.HTTPClient {
 	return &http.Client{
 		Transport: &http2.Transport{
+			TLSClientConfig:  tlsconfig.NewOpenAPI(),
 			PingTimeout:      3 * time.Second,
 			ReadIdleTimeout:  3 * time.Second,
 			WriteByteTimeout: 3 * time.Second,

--- a/api/api_utils/connect_client_test.go
+++ b/api/api_utils/connect_client_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api_utils
+
+import (
+	"crypto/tls"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"golang.org/x/net/http2"
+)
+
+func TestNewConnectClientUsesOpenAPITLSPolicy(t *testing.T) {
+	got := NewConnectClient()
+	client, ok := got.(*http.Client)
+	if !ok {
+		t.Fatalf("client type = %T, want *http.Client", got)
+	}
+	transport, ok := client.Transport.(*http2.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http2.Transport", client.Transport)
+	}
+	wantCipherSuites := []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	}
+
+	config := transport.TLSClientConfig
+	if config.MinVersion != tls.VersionTLS12 || config.MaxVersion != tls.VersionTLS12 {
+		t.Fatalf("OpenAPI transport must allow TLS 1.2 only")
+	}
+	if !reflect.DeepEqual(config.CipherSuites, wantCipherSuites) {
+		t.Fatalf("cipher suites = %#v, want %#v", config.CipherSuites, wantCipherSuites)
+	}
+}

--- a/cmd/cocli/main.go
+++ b/cmd/cocli/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/coscene-io/cocli/internal/iostreams"
 	"github.com/coscene-io/cocli/internal/utils"
 	"github.com/coscene-io/cocli/pkg/cmd"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
 	"github.com/getsentry/sentry-go"
 	log "github.com/sirupsen/logrus"
 )
@@ -91,8 +92,9 @@ func watchForceQuit(ctx context.Context, quit <-chan os.Signal, onForceQuit func
 
 func newSentryClientOptions() sentry.ClientOptions {
 	return sentry.ClientOptions{
-		Dsn:     "https://b3bcd9e4d101f927b5f1f7ac67d9b115@sentry.coscene.site/23",
-		Release: cocli.GetVersion(),
+		Dsn:           "https://b3bcd9e4d101f927b5f1f7ac67d9b115@sentry.coscene.site/23",
+		Release:       cocli.GetVersion(),
+		HTTPTransport: cmd_utils.NewTransport(30 * time.Second),
 		// Set TracesSampleRate to 1.0 to capture 100%
 		// of transactions for tracing.
 		// We recommend adjusting this value in production,

--- a/cmd/cocli/main_test.go
+++ b/cmd/cocli/main_test.go
@@ -16,7 +16,10 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"net/http"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -37,6 +40,22 @@ func TestNewSentryClientOptions(t *testing.T) {
 	}
 	if !opts.AttachStacktrace {
 		t.Fatalf("expected AttachStacktrace to be true")
+	}
+	transport, ok := opts.HTTPTransport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Sentry transport type = %T, want *http.Transport", opts.HTTPTransport)
+	}
+	wantCipherSuites := []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	}
+	if transport.TLSClientConfig.MinVersion != tls.VersionTLS12 || transport.TLSClientConfig.MaxVersion != tls.VersionTLS12 {
+		t.Fatalf("Sentry transport must allow TLS 1.2 only")
+	}
+	if !reflect.DeepEqual(transport.TLSClientConfig.CipherSuites, wantCipherSuites) {
+		t.Fatalf("Sentry cipher suites = %#v, want %#v", transport.TLSClientConfig.CipherSuites, wantCipherSuites)
 	}
 }
 

--- a/internal/tlsconfig/tlsconfig.go
+++ b/internal/tlsconfig/tlsconfig.go
@@ -1,0 +1,48 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlsconfig
+
+import "crypto/tls"
+
+var (
+	openAPICipherSuites = []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	}
+	generalCipherSuites = []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	}
+)
+
+// NewOpenAPI returns the TLS policy for HTTP/2 OpenAPI requests.
+func NewOpenAPI() *tls.Config {
+	return newConfig(openAPICipherSuites)
+}
+
+// NewGeneral returns the TLS policy for all other outbound HTTPS requests.
+func NewGeneral() *tls.Config {
+	return newConfig(generalCipherSuites)
+}
+
+func newConfig(cipherSuites []uint16) *tls.Config {
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		MaxVersion:   tls.VersionTLS12,
+		CipherSuites: append([]uint16(nil), cipherSuites...),
+	}
+}

--- a/internal/tlsconfig/tlsconfig_test.go
+++ b/internal/tlsconfig/tlsconfig_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlsconfig
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestOpenAPIPolicy(t *testing.T) {
+	want := []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	}
+	assertPolicy(t, NewOpenAPI(), want)
+}
+
+func TestGeneralPolicy(t *testing.T) {
+	want := []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	}
+	assertPolicy(t, NewGeneral(), want)
+}
+
+func TestPoliciesReturnIndependentConfigs(t *testing.T) {
+	first := NewGeneral()
+	second := NewGeneral()
+	first.MinVersion = tls.VersionTLS11
+	first.CipherSuites[0] = tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+
+	if second.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("mutating one config changed another config's minimum TLS version")
+	}
+	if second.CipherSuites[0] != tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 {
+		t.Fatalf("mutating one config changed another config's cipher suites")
+	}
+}
+
+func TestGeneralPolicyTLSHandshake(t *testing.T) {
+	for _, cipherSuite := range generalCipherSuites {
+		t.Run("allows "+tls.CipherSuiteName(cipherSuite), func(t *testing.T) {
+			server := newTLSServer(t, tls.VersionTLS12, tls.VersionTLS12, []uint16{cipherSuite})
+			defer server.Close()
+
+			client := clientForTestServer(server, NewGeneral())
+			resp, err := client.Get(server.URL)
+			if err != nil {
+				t.Fatalf("request with allowed TLS policy failed: %v", err)
+			}
+			_ = resp.Body.Close()
+			if resp.TLS.Version != tls.VersionTLS12 {
+				t.Fatalf("negotiated TLS version %x, want TLS 1.2", resp.TLS.Version)
+			}
+			if resp.TLS.CipherSuite != cipherSuite {
+				t.Fatalf("negotiated cipher suite %x, want %x", resp.TLS.CipherSuite, cipherSuite)
+			}
+		})
+	}
+
+	t.Run("rejects TLS 1.3", func(t *testing.T) {
+		server := newTLSServer(t, tls.VersionTLS13, tls.VersionTLS13, nil)
+		defer server.Close()
+
+		_, err := clientForTestServer(server, NewGeneral()).Get(server.URL)
+		if err == nil {
+			t.Fatal("expected TLS 1.3-only server to be rejected")
+		}
+	})
+
+	for _, cipherSuite := range []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	} {
+		t.Run("rejects "+tls.CipherSuiteName(cipherSuite), func(t *testing.T) {
+			server := newTLSServer(t, tls.VersionTLS12, tls.VersionTLS12, []uint16{cipherSuite})
+			defer server.Close()
+
+			_, err := clientForTestServer(server, NewGeneral()).Get(server.URL)
+			if err == nil {
+				t.Fatalf("expected server limited to %s to be rejected", tls.CipherSuiteName(cipherSuite))
+			}
+		})
+	}
+}
+
+func TestOpenAPIPolicyRejectsStaticRSA(t *testing.T) {
+	server := newTLSServer(t, tls.VersionTLS12, tls.VersionTLS12, []uint16{
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	})
+	defer server.Close()
+
+	_, err := clientForTestServer(server, NewOpenAPI()).Get(server.URL)
+	if err == nil {
+		t.Fatal("expected OpenAPI policy to reject static RSA cipher suite")
+	}
+}
+
+func assertPolicy(t *testing.T, config *tls.Config, wantCipherSuites []uint16) {
+	t.Helper()
+	if config.MinVersion != tls.VersionTLS12 || config.MaxVersion != tls.VersionTLS12 {
+		t.Fatalf("TLS versions = %x-%x, want TLS 1.2 only", config.MinVersion, config.MaxVersion)
+	}
+	if !reflect.DeepEqual(config.CipherSuites, wantCipherSuites) {
+		t.Fatalf("cipher suites = %#v, want %#v", config.CipherSuites, wantCipherSuites)
+	}
+}
+
+func newTLSServer(t *testing.T, minVersion, maxVersion uint16, cipherSuites []uint16) *httptest.Server {
+	t.Helper()
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	server.TLS = &tls.Config{
+		MinVersion:   minVersion,
+		MaxVersion:   maxVersion,
+		CipherSuites: cipherSuites,
+	}
+	server.StartTLS()
+	return server
+}
+
+func clientForTestServer(server *httptest.Server, config *tls.Config) *http.Client {
+	config.RootCAs = server.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs
+	return &http.Client{Transport: &http.Transport{TLSClientConfig: config}}
+}

--- a/pkg/cmd/action/logs.go
+++ b/pkg/cmd/action/logs.go
@@ -45,6 +45,8 @@ const (
 	reconnectMaxDelay    = 30 * time.Second
 )
 
+var archivedLogHTTPClient = cmd_utils.NewHTTPClient()
+
 func NewLogsCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(string) config.Provider) *cobra.Command {
 	var (
 		projectSlug = ""
@@ -351,7 +353,7 @@ func printArchivedLog(ctx context.Context, downloadURL string, io *iostreams.IOS
 	if err != nil {
 		return fmt.Errorf("build archived log request: %w", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := archivedLogHTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("download archived log: %w", err)
 	}

--- a/pkg/cmd/update.go
+++ b/pkg/cmd/update.go
@@ -15,6 +15,9 @@
 package cmd
 
 import (
+	"fmt"
+	"io"
+	"net/http"
 	"os"
 
 	"github.com/coscene-io/cocli"
@@ -26,6 +29,27 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
+
+type updateRequester struct {
+	client *http.Client
+}
+
+func newUpdateRequester() *updateRequester {
+	return &updateRequester{client: cmd_utils.NewHTTPClient()}
+}
+
+func (r *updateRequester) Fetch(url string) (io.ReadCloser, error) {
+	resp, err := r.client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("bad http status from %s: %s", url, resp.Status)
+	}
+
+	return resp.Body, nil
+}
 
 func NewUpdateCommand(io *iostreams.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
@@ -44,6 +68,7 @@ func NewUpdateCommand(io *iostreams.IOStreams) *cobra.Command {
 				BinURL:         constants.DownloadBaseUrl,
 				CmdName:        constants.CLIName,
 				ForceCheck:     true,
+				Requester:      newUpdateRequester(),
 				OnSuccessfulUpdate: func() {
 					io.Println("Successfully updated to the latest version")
 				},

--- a/pkg/cmd/update_test.go
+++ b/pkg/cmd/update_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"crypto/tls"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestNewUpdateRequesterUsesGeneralTLSPolicy(t *testing.T) {
+	requester := newUpdateRequester()
+	transport, ok := requester.client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", requester.client.Transport)
+	}
+	if transport.TLSClientConfig.MinVersion != tls.VersionTLS12 || transport.TLSClientConfig.MaxVersion != tls.VersionTLS12 {
+		t.Fatalf("self-update transport must allow TLS 1.2 only")
+	}
+	if got := len(transport.TLSClientConfig.CipherSuites); got != 4 {
+		t.Fatalf("self-update cipher suite count = %d, want 4", got)
+	}
+}
+
+func TestUpdateRequesterFetch(t *testing.T) {
+	t.Run("returns successful response body", func(t *testing.T) {
+		body := &trackingReadCloser{Reader: strings.NewReader("update")}
+		requester := &updateRequester{client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Body: body}, nil
+		})}}
+
+		got, err := requester.Fetch("https://updates.example.test/version")
+		if err != nil {
+			t.Fatalf("Fetch returned error: %v", err)
+		}
+		if got != body {
+			t.Fatalf("Fetch returned an unexpected body")
+		}
+		if body.closed {
+			t.Fatal("successful response body was closed before the caller could read it")
+		}
+		_ = got.Close()
+	})
+
+	t.Run("closes non-200 response body", func(t *testing.T) {
+		body := &trackingReadCloser{Reader: strings.NewReader("failure")}
+		requester := &updateRequester{client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusBadGateway, Status: "502 Bad Gateway", Body: body}, nil
+		})}}
+
+		got, err := requester.Fetch("https://updates.example.test/version")
+		if err == nil || !strings.Contains(err.Error(), "502 Bad Gateway") {
+			t.Fatalf("Fetch error = %v, want HTTP status error", err)
+		}
+		if got != nil {
+			t.Fatalf("Fetch body = %v, want nil", got)
+		}
+		if !body.closed {
+			t.Fatal("non-200 response body was not closed")
+		}
+	})
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type trackingReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (r *trackingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}

--- a/pkg/cmd_utils/transport.go
+++ b/pkg/cmd_utils/transport.go
@@ -1,10 +1,11 @@
 package cmd_utils
 
 import (
-	"crypto/tls"
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/coscene-io/cocli/internal/tlsconfig"
 )
 
 func NewTransport(timeout time.Duration) *http.Transport {
@@ -27,12 +28,12 @@ func NewTransport(timeout time.Duration) *http.Transport {
 		// Refer:
 		//    https://golang.org/src/net/http/transport.go?h=roundTrip#L1843
 		DisableCompression: true,
-		TLSClientConfig: &tls.Config{
-			// Can't use SSLv3 because of POODLE and BEAST
-			// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
-			// Can't use TLSv1.1 because of RC4 cipher usage
-			MinVersion: tls.VersionTLS12,
-		},
+		TLSClientConfig:    tlsconfig.NewGeneral(),
 	}
 
+}
+
+// NewHTTPClient returns an HTTP client using the general outbound TLS policy.
+func NewHTTPClient() *http.Client {
+	return &http.Client{Transport: NewTransport(0)}
 }

--- a/pkg/cmd_utils/transport_test.go
+++ b/pkg/cmd_utils/transport_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd_utils
+
+import (
+	"crypto/tls"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestNewTransportUsesGeneralTLSPolicy(t *testing.T) {
+	transport := NewTransport(15 * time.Second)
+	wantCipherSuites := []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	}
+
+	if transport.ResponseHeaderTimeout != 15*time.Second {
+		t.Fatalf("response header timeout = %s, want 15s", transport.ResponseHeaderTimeout)
+	}
+	if transport.TLSClientConfig.MinVersion != tls.VersionTLS12 || transport.TLSClientConfig.MaxVersion != tls.VersionTLS12 {
+		t.Fatalf("transport must allow TLS 1.2 only")
+	}
+	if !reflect.DeepEqual(transport.TLSClientConfig.CipherSuites, wantCipherSuites) {
+		t.Fatalf("cipher suites = %#v, want %#v", transport.TLSClientConfig.CipherSuites, wantCipherSuites)
+	}
+}
+
+func TestNewHTTPClientUsesNewTransport(t *testing.T) {
+	client := NewHTTPClient()
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", client.Transport)
+	}
+	if transport.TLSClientConfig.MaxVersion != tls.VersionTLS12 {
+		t.Fatalf("maximum TLS version = %x, want TLS 1.2", transport.TLSClientConfig.MaxVersion)
+	}
+}

--- a/pkg/cmd_utils/url_utils.go
+++ b/pkg/cmd_utils/url_utils.go
@@ -35,6 +35,8 @@ const (
 	retryWaitMax = 5 * time.Second
 )
 
+var downloadHTTPClient = NewHTTPClient()
+
 // Progress is a simple struct to keep track of the progress of a file upload/download
 type Progress struct {
 	PrintPrefix string
@@ -128,7 +130,7 @@ func downloadFileThroughUrl(file string, downloadUrl string, maxRetries int, ini
 func downloadWithFileWriter(fileWriter *os.File, downloadUrl string, retry int) error {
 	defer fmt.Print("\r\033[K")
 
-	resp, err := http.Get(downloadUrl)
+	resp, err := downloadHTTPClient.Get(downloadUrl)
 	if err != nil {
 		return errors.Wrapf(err, "unable to get file from url %v", downloadUrl)
 	}


### PR DESCRIPTION
## Summary

- pin all outbound HTTPS connections to TLS 1.2
- restrict OpenAPI HTTP/2 connections to the two approved ECDHE-RSA AES-GCM cipher suites
- apply the four-suite general policy to Sentry, object storage uploads/downloads, archived action logs, and self-update traffic
- add policy, transport, requester, and TLS handshake regression tests

## Validation

- `go test -race ./... -count=1`
- dev OpenAPI integration suite: 8/8 passed
- dev record upload/download round trip with matching SHA-256
- Sentry event delivery and flush succeeded
- self-update flow succeeded against `download.coscene.cn`
- action run succeeded and archived logs downloaded over TLS 1.2 with `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`

## TLS policies

OpenAPI:
- `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
- `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`

Other outbound HTTPS:
- the two suites above
- `TLS_RSA_WITH_AES_256_GCM_SHA384`
- `TLS_RSA_WITH_AES_128_GCM_SHA256`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coCLI/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789106690&installation_model_id=425002&pr_number=192&repository=coscene-io%2FcoCLI&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoCLI%2Fpull%2F192&signature=ecd55db912832d0e845a54f5c6b03a5bf5a5fe650a49e28706c5c42f99bb7407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->