### PR TITLE
feat(record): add moment deletion

### DIFF
--- a/api/event.go
+++ b/api/event.go
@@ -21,12 +21,19 @@ import (
 	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
 	openv1alpha1service "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/services"
 	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/internal/name"
 	"github.com/pkg/errors"
 )
 
 type EventInterface interface {
 	// ObtainEvent creates an event if not found, fetches otherwise.
 	ObtainEvent(ctx context.Context, parent string, event *openv1alpha1resource.Event) (*openv1alpha1service.ObtainEventResponse, error)
+
+	// GetEvent gets an event by name.
+	GetEvent(ctx context.Context, eventName *name.Event) (*openv1alpha1resource.Event, error)
+
+	// DeleteEvent deletes an event by name.
+	DeleteEvent(ctx context.Context, eventName *name.Event) error
 }
 
 type eventClient struct {
@@ -50,4 +57,26 @@ func (c *eventClient) ObtainEvent(ctx context.Context, parent string, event *ope
 	}
 
 	return createEventRes.Msg, nil
+}
+
+func (c *eventClient) GetEvent(ctx context.Context, eventName *name.Event) (*openv1alpha1resource.Event, error) {
+	res, err := c.eventClient.GetEvent(ctx, connect.NewRequest(&openv1alpha1service.GetEventRequest{
+		Name: eventName.String(),
+	}))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get event %s", eventName)
+	}
+
+	return res.Msg, nil
+}
+
+func (c *eventClient) DeleteEvent(ctx context.Context, eventName *name.Event) error {
+	_, err := c.eventClient.DeleteEvent(ctx, connect.NewRequest(&openv1alpha1service.DeleteEventRequest{
+		Name: eventName.String(),
+	}))
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete event %s", eventName)
+	}
+
+	return nil
 }

--- a/api/event_test.go
+++ b/api/event_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	openv1alpha1connect "buf.build/gen/go/coscene-io/coscene-openapi/connectrpc/go/coscene/openapi/dataplatform/v1alpha1/services/servicesconnect"
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	openv1alpha1service "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/services"
+	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/internal/name"
+	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+const eventTestName = "projects/11111111-1111-1111-1111-111111111111/events/22222222-2222-2222-2222-222222222222"
+
+type mockEventServiceClient struct {
+	openv1alpha1connect.EventServiceClient
+	getEventFunc    func(context.Context, *connect.Request[openv1alpha1service.GetEventRequest]) (*connect.Response[openv1alpha1resource.Event], error)
+	deleteEventFunc func(context.Context, *connect.Request[openv1alpha1service.DeleteEventRequest]) (*connect.Response[emptypb.Empty], error)
+}
+
+func (m *mockEventServiceClient) GetEvent(ctx context.Context, req *connect.Request[openv1alpha1service.GetEventRequest]) (*connect.Response[openv1alpha1resource.Event], error) {
+	return m.getEventFunc(ctx, req)
+}
+
+func (m *mockEventServiceClient) DeleteEvent(ctx context.Context, req *connect.Request[openv1alpha1service.DeleteEventRequest]) (*connect.Response[emptypb.Empty], error) {
+	return m.deleteEventFunc(ctx, req)
+}
+
+func TestEventClientGetEvent(t *testing.T) {
+	eventName, err := name.NewEvent(eventTestName)
+	require.NoError(t, err)
+
+	mock := &mockEventServiceClient{
+		getEventFunc: func(_ context.Context, req *connect.Request[openv1alpha1service.GetEventRequest]) (*connect.Response[openv1alpha1resource.Event], error) {
+			assert.Equal(t, eventTestName, req.Msg.GetName())
+			return connect.NewResponse(&openv1alpha1resource.Event{Name: eventTestName, DisplayName: "Collision"}), nil
+		},
+	}
+
+	event, err := NewEventClient(mock).GetEvent(context.Background(), eventName)
+	require.NoError(t, err)
+	assert.Equal(t, "Collision", event.GetDisplayName())
+}
+
+func TestEventClientGetEventPreservesConnectError(t *testing.T) {
+	eventName, err := name.NewEvent(eventTestName)
+	require.NoError(t, err)
+
+	mock := &mockEventServiceClient{
+		getEventFunc: func(context.Context, *connect.Request[openv1alpha1service.GetEventRequest]) (*connect.Response[openv1alpha1resource.Event], error) {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("missing"))
+		},
+	}
+
+	_, err = NewEventClient(mock).GetEvent(context.Background(), eventName)
+	require.Error(t, err)
+	assert.True(t, utils.IsConnectErrorWithCode(err, connect.CodeNotFound))
+}
+
+func TestEventClientDeleteEvent(t *testing.T) {
+	eventName, err := name.NewEvent(eventTestName)
+	require.NoError(t, err)
+
+	mock := &mockEventServiceClient{
+		deleteEventFunc: func(_ context.Context, req *connect.Request[openv1alpha1service.DeleteEventRequest]) (*connect.Response[emptypb.Empty], error) {
+			assert.Equal(t, eventTestName, req.Msg.GetName())
+			return connect.NewResponse(&emptypb.Empty{}), nil
+		},
+	}
+
+	require.NoError(t, NewEventClient(mock).DeleteEvent(context.Background(), eventName))
+}
+
+func TestEventClientDeleteEventPreservesConnectError(t *testing.T) {
+	eventName, err := name.NewEvent(eventTestName)
+	require.NoError(t, err)
+
+	mock := &mockEventServiceClient{
+		deleteEventFunc: func(context.Context, *connect.Request[openv1alpha1service.DeleteEventRequest]) (*connect.Response[emptypb.Empty], error) {
+			return nil, connect.NewError(connect.CodePermissionDenied, errors.New("denied"))
+		},
+	}
+
+	err = NewEventClient(mock).DeleteEvent(context.Background(), eventName)
+	require.Error(t, err)
+	assert.True(t, utils.IsConnectErrorWithCode(err, connect.CodePermissionDenied))
+}

--- a/internal/name/event.go
+++ b/internal/name/event.go
@@ -1,0 +1,46 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package name
+
+import (
+	"fmt"
+
+	"github.com/oriser/regroup"
+	"github.com/pkg/errors"
+)
+
+type Event struct {
+	ProjectID string
+	ID        string
+}
+
+var eventNameRe = regroup.MustCompile(`^projects/(?P<project>[^/]+)/events/(?P<event>[^/]+)$`)
+
+func NewEvent(event string) (*Event, error) {
+	match, err := eventNameRe.Groups(event)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse event name")
+	}
+
+	return &Event{ProjectID: match["project"], ID: match["event"]}, nil
+}
+
+func (e Event) Project() *Project {
+	return &Project{ProjectID: e.ProjectID}
+}
+
+func (e Event) String() string {
+	return fmt.Sprintf("projects/%s/events/%s", e.ProjectID, e.ID)
+}

--- a/internal/name/event_test.go
+++ b/internal/name/event_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package name
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEvent(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantProject string
+		wantEvent   string
+		wantErr     bool
+	}{
+		{
+			name:        "valid",
+			input:       "projects/11111111-1111-1111-1111-111111111111/events/22222222-2222-2222-2222-222222222222",
+			wantProject: "11111111-1111-1111-1111-111111111111",
+			wantEvent:   "22222222-2222-2222-2222-222222222222",
+		},
+		{name: "missing events segment", input: "projects/p1/e1", wantErr: true},
+		{name: "extra segment", input: "projects/p1/events/e1/details", wantErr: true},
+		{name: "empty", input: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event, err := NewEvent(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantProject, event.ProjectID)
+			assert.Equal(t, tt.wantEvent, event.ID)
+			assert.Equal(t, tt.input, event.String())
+			assert.Equal(t, tt.wantProject, event.Project().ProjectID)
+		})
+	}
+}

--- a/internal/printer/printable/event.go
+++ b/internal/printer/printable/event.go
@@ -19,13 +19,15 @@ import (
 
 	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
 	openv1alpha1service "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/services"
+	"github.com/coscene-io/cocli/internal/name"
 	"github.com/coscene-io/cocli/internal/printer/table"
 	"google.golang.org/protobuf/proto"
 )
 
 const (
-	eventNameTrimSize = 20
-	eventTimeTrimSize = len(time.RFC3339)
+	eventIDTrimSize          = 36
+	eventDisplayNameTrimSize = 20
+	eventTimeTrimSize        = len(time.RFC3339)
 )
 
 type Event struct {
@@ -48,11 +50,22 @@ func (p *Event) ToProtoMessage() proto.Message {
 func (p *Event) ToTable(opts *table.PrintOpts) table.Table {
 	fullColumnDefs := []table.ColumnDefinitionFull[*openv1alpha1resource.Event]{
 		{
-			FieldName: "NAME",
+			FieldName: "ID",
+			FieldValueFunc: func(e *openv1alpha1resource.Event, opts *table.PrintOpts) string {
+				eventName, err := name.NewEvent(e.Name)
+				if err != nil {
+					return e.Name
+				}
+				return eventName.ID
+			},
+			TrimSize: eventIDTrimSize,
+		},
+		{
+			FieldName: "DISPLAY NAME",
 			FieldValueFunc: func(e *openv1alpha1resource.Event, opts *table.PrintOpts) string {
 				return e.DisplayName
 			},
-			TrimSize: eventNameTrimSize,
+			TrimSize: eventDisplayNameTrimSize,
 		},
 		{
 			FieldName: "TRIGGER TIME",

--- a/internal/printer/printable/event_test.go
+++ b/internal/printer/printable/event_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package printable
+
+import (
+	"testing"
+	"time"
+
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"github.com/coscene-io/cocli/internal/printer/table"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestEvent_ToTable(t *testing.T) {
+	triggerTime := time.Date(2026, 6, 4, 3, 21, 17, 0, time.UTC)
+	events := []*openv1alpha1resource.Event{
+		{
+			Name:        "projects/project-id/events/25ed8af0-4baf-43fa-8b2e-1e26f7b395b2",
+			DisplayName: "test",
+			TriggerTime: timestamppb.New(triggerTime),
+			Duration:    durationpb.New(0),
+		},
+	}
+
+	tbl := NewEvent(events).ToTable(&table.PrintOpts{})
+
+	require.Len(t, tbl.ColumnDefs, 4)
+	assert.Equal(t, []string{"ID", "DISPLAY NAME", "TRIGGER TIME", "DURATION"}, []string{
+		tbl.ColumnDefs[0].FieldName,
+		tbl.ColumnDefs[1].FieldName,
+		tbl.ColumnDefs[2].FieldName,
+		tbl.ColumnDefs[3].FieldName,
+	})
+	require.Len(t, tbl.Rows, 1)
+	assert.Equal(t, []string{
+		"25ed8af0-4baf-43fa-8b2e-1e26f7b395b2",
+		"test",
+		triggerTime.In(time.Local).Format(time.RFC3339),
+		"0s",
+	}, tbl.Rows[0])
+}

--- a/pkg/cmd/record/moment.go
+++ b/pkg/cmd/record/moment.go
@@ -45,6 +45,7 @@ func NewMomentCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func
 	}
 
 	cmd.AddCommand(NewMomentCreateCommand(cfgPath, io, getProvider))
+	cmd.AddCommand(NewMomentDeleteCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewMomentListCommand(cfgPath, io, getProvider))
 	cmd.AddCommand(NewMomentDownloadCommand(cfgPath, io, getProvider))
 

--- a/pkg/cmd/record/moment_delete.go
+++ b/pkg/cmd/record/moment_delete.go
@@ -1,0 +1,114 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+import (
+	"context"
+	"fmt"
+
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/internal/name"
+	"github.com/coscene-io/cocli/internal/prompts"
+	"github.com/coscene-io/cocli/pkg/cmd_utils"
+	"github.com/spf13/cobra"
+)
+
+const momentDeleteConfirmation = "Delete this moment? This cannot be undone."
+
+type momentDeleter interface {
+	GetEvent(context.Context, *name.Event) (*openv1alpha1resource.Event, error)
+	DeleteEvent(context.Context, *name.Event) error
+}
+
+type confirmMomentDelete func(string, *iostreams.IOStreams) bool
+
+func NewMomentDeleteCommand(cfgPath *string, io *iostreams.IOStreams, getProvider func(string) config.Provider) *cobra.Command {
+	var (
+		force       bool
+		projectSlug string
+	)
+
+	cmd := &cobra.Command{
+		Use:                   "delete <moment-resource-name/id> [-p <working-project-slug>] [-f]",
+		Short:                 "Delete a moment from a record",
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+
+			pm := cmd_utils.ProfileManager(cmd, getProvider, *cfgPath)
+			eventName, err := resolveMomentName(args[0], func() (*name.Project, error) {
+				proj, projectErr := pm.ProjectName(cmd.Context(), projectSlug)
+				if projectErr != nil {
+					return nil, fmt.Errorf("unable to get project name: %w", projectErr)
+				}
+				return proj, nil
+			})
+			if err != nil {
+				return err
+			}
+
+			return deleteMoment(cmd.Context(), io, pm.EventCli(), eventName, force, prompts.PromptYN)
+		},
+	}
+
+	cmd.Flags().StringVarP(&projectSlug, "project", "p", "", "the slug of the working project")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "delete without confirmation")
+
+	return cmd
+}
+
+func resolveMomentName(momentRef string, resolveProject func() (*name.Project, error)) (*name.Event, error) {
+	if eventName, err := name.NewEvent(momentRef); err == nil {
+		return eventName, nil
+	}
+	if !name.IsUUID(momentRef) {
+		return nil, fmt.Errorf("invalid moment resource name or id: %s", momentRef)
+	}
+
+	proj, err := resolveProject()
+	if err != nil {
+		return nil, err
+	}
+	return &name.Event{ProjectID: proj.ProjectID, ID: momentRef}, nil
+}
+
+func deleteMoment(ctx context.Context, io *iostreams.IOStreams, cli momentDeleter, eventName *name.Event, force bool, confirm confirmMomentDelete) error {
+	event, err := cli.GetEvent(ctx, eventName)
+	if err != nil {
+		return fmt.Errorf("failed to get moment %s: %w", eventName, err)
+	}
+
+	displayName := event.GetDisplayName()
+	if displayName == "" {
+		displayName = "<unnamed>"
+	}
+	io.Printf("Moment: %s (%s)\n", displayName, eventName)
+
+	if !force && !confirm(momentDeleteConfirmation, io) {
+		io.Println("Moment deletion aborted.")
+		return nil
+	}
+
+	if err = cli.DeleteEvent(ctx, eventName); err != nil {
+		return fmt.Errorf("failed to delete moment %s: %w", eventName, err)
+	}
+
+	io.Printf("Moment successfully deleted: %s\n", eventName)
+	return nil
+}

--- a/pkg/cmd/record/moment_delete_test.go
+++ b/pkg/cmd/record/moment_delete_test.go
@@ -1,0 +1,274 @@
+// Copyright 2026 coScene
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	openv1alpha1resource "buf.build/gen/go/coscene-io/coscene-openapi/protocolbuffers/go/coscene/openapi/dataplatform/v1alpha1/resources"
+	"connectrpc.com/connect"
+	"github.com/coscene-io/cocli/internal/config"
+	"github.com/coscene-io/cocli/internal/iostreams"
+	"github.com/coscene-io/cocli/internal/name"
+	"github.com/coscene-io/cocli/internal/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	momentTestProjectID = "11111111-1111-1111-1111-111111111111"
+	momentTestID        = "22222222-2222-2222-2222-222222222222"
+	momentTestName      = "projects/" + momentTestProjectID + "/events/" + momentTestID
+)
+
+type fakeMomentDeleter struct {
+	event      *openv1alpha1resource.Event
+	getErr     error
+	deleteErr  error
+	gotGet     *name.Event
+	gotDeleted *name.Event
+	calls      []string
+}
+
+func (f *fakeMomentDeleter) GetEvent(_ context.Context, eventName *name.Event) (*openv1alpha1resource.Event, error) {
+	f.calls = append(f.calls, "get")
+	f.gotGet = eventName
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if f.event != nil {
+		return f.event, nil
+	}
+	return &openv1alpha1resource.Event{Name: eventName.String(), DisplayName: "Collision"}, nil
+}
+
+func (f *fakeMomentDeleter) DeleteEvent(_ context.Context, eventName *name.Event) error {
+	f.calls = append(f.calls, "delete")
+	f.gotDeleted = eventName
+	return f.deleteErr
+}
+
+func TestMomentDeleteCommandRegistrationAndFlags(t *testing.T) {
+	cfgPath := t.TempDir() + "/test-config.yaml"
+	var out bytes.Buffer
+	io := iostreams.Test(nil, &out, &out)
+	cmd := NewMomentCommand(&cfgPath, io, config.Provide)
+
+	deleteCmd, _, err := cmd.Find([]string{"delete"})
+	require.NoError(t, err)
+	assert.Equal(t, "delete", deleteCmd.Name())
+	assert.NotNil(t, deleteCmd.Flag("project"))
+	assert.Equal(t, "p", deleteCmd.Flag("project").Shorthand)
+	assert.NotNil(t, deleteCmd.Flag("force"))
+	assert.Equal(t, "f", deleteCmd.Flag("force").Shorthand)
+	assert.Error(t, deleteCmd.Args(deleteCmd, nil))
+	assert.NoError(t, deleteCmd.Args(deleteCmd, []string{momentTestID}))
+	assert.Error(t, deleteCmd.Args(deleteCmd, []string{momentTestID, "extra"}))
+}
+
+func TestMomentDeleteRuntimeErrorDoesNotPrintUsage(t *testing.T) {
+	var out bytes.Buffer
+	io := iostreams.Test(nil, &out, &out)
+	cfgPath := t.TempDir() + "/test-config.yaml"
+	cmd := NewMomentDeleteCommand(&cfgPath, io, nil)
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetContext(config.ContextWithProfileManager(context.Background(), &config.ProfileManager{
+		CurrentProfile: "test",
+		Profiles: []*config.Profile{{
+			Name:        "test",
+			EndPoint:    "http://127.0.0.1:0",
+			Token:       "test-token",
+			ProjectSlug: "test-project",
+			ProjectName: "projects/" + momentTestProjectID,
+		}},
+	}))
+	cmd.SetArgs([]string{momentTestName, "--force"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.NotContains(t, out.String(), "Usage:")
+	assert.NotContains(t, out.String(), "Error:")
+}
+
+func TestMomentDeleteArgumentErrorPrintsUsage(t *testing.T) {
+	var out bytes.Buffer
+	io := iostreams.Test(nil, &out, &out)
+	cfgPath := t.TempDir() + "/test-config.yaml"
+	cmd := NewMomentDeleteCommand(&cfgPath, io, nil)
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, out.String(), "Usage:")
+}
+
+func TestMomentDeleteInvalidReferenceDoesNotResolveProject(t *testing.T) {
+	var out bytes.Buffer
+	io := iostreams.Test(nil, &out, &out)
+	cfgPath := t.TempDir() + "/test-config.yaml"
+	cmd := NewMomentDeleteCommand(&cfgPath, io, nil)
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetContext(config.ContextWithProfileManager(context.Background(), &config.ProfileManager{
+		CurrentProfile: "test",
+		Profiles: []*config.Profile{{
+			Name: "test",
+		}},
+	}))
+	cmd.SetArgs([]string{"not-a-moment", "--project", "missing-project", "--force"})
+
+	err := cmd.Execute()
+	assert.EqualError(t, err, "invalid moment resource name or id: not-a-moment")
+	assert.NotContains(t, out.String(), "Usage:")
+}
+
+func TestResolveMomentName(t *testing.T) {
+	project := &name.Project{ProjectID: momentTestProjectID}
+
+	t.Run("full resource name takes precedence", func(t *testing.T) {
+		eventName, err := resolveMomentName(momentTestName, func() (*name.Project, error) {
+			t.Fatal("full resource name must not resolve a project")
+			return nil, nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, momentTestName, eventName.String())
+	})
+
+	t.Run("bare UUID uses selected project", func(t *testing.T) {
+		eventName, err := resolveMomentName(momentTestID, func() (*name.Project, error) {
+			return project, nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, momentTestName, eventName.String())
+	})
+
+	t.Run("invalid reference does not resolve a project", func(t *testing.T) {
+		_, err := resolveMomentName("not-a-moment", func() (*name.Project, error) {
+			t.Fatal("invalid reference must not resolve a project")
+			return nil, nil
+		})
+		assert.EqualError(t, err, "invalid moment resource name or id: not-a-moment")
+	})
+
+	t.Run("project error", func(t *testing.T) {
+		_, err := resolveMomentName(momentTestID, func() (*name.Project, error) {
+			return nil, errors.New("project unavailable")
+		})
+		assert.EqualError(t, err, "project unavailable")
+	})
+}
+
+func TestDeleteMomentRefusalDoesNotDelete(t *testing.T) {
+	cli := &fakeMomentDeleter{}
+	io, out := momentDeleteTestIO()
+	confirmed := false
+
+	err := deleteMoment(context.Background(), io, cli, mustMomentName(t), false, func(prompt string, _ *iostreams.IOStreams) bool {
+		confirmed = true
+		assert.Contains(t, prompt, "cannot be undone")
+		return false
+	})
+
+	require.NoError(t, err)
+	assert.True(t, confirmed)
+	assert.NotNil(t, cli.gotGet)
+	assert.Nil(t, cli.gotDeleted)
+	assert.Contains(t, out.String(), "Collision")
+	assert.Contains(t, out.String(), momentTestName)
+	assert.Contains(t, out.String(), "Moment deletion aborted.")
+}
+
+func TestDeleteMomentForceSkipsConfirmation(t *testing.T) {
+	cli := &fakeMomentDeleter{}
+	io, out := momentDeleteTestIO()
+
+	err := deleteMoment(context.Background(), io, cli, mustMomentName(t), true, failIfMomentConfirmed(t))
+	require.NoError(t, err)
+	assert.NotNil(t, cli.gotGet)
+	assert.NotNil(t, cli.gotDeleted)
+	assert.Equal(t, []string{"get", "delete"}, cli.calls)
+	assert.Contains(t, out.String(), "Moment successfully deleted")
+}
+
+func TestDeleteMomentConfirmationAccepts(t *testing.T) {
+	cli := &fakeMomentDeleter{}
+	io, out := momentDeleteTestIO()
+	confirmed := false
+
+	err := deleteMoment(context.Background(), io, cli, mustMomentName(t), false, func(prompt string, _ *iostreams.IOStreams) bool {
+		confirmed = true
+		assert.Equal(t, momentDeleteConfirmation, prompt)
+		return true
+	})
+
+	require.NoError(t, err)
+	assert.True(t, confirmed)
+	assert.Equal(t, []string{"get", "delete"}, cli.calls)
+	assert.Equal(t, momentTestName, cli.gotDeleted.String())
+	assert.Contains(t, out.String(), "Moment successfully deleted: "+momentTestName)
+}
+
+func TestDeleteMomentShowsUnnamedTarget(t *testing.T) {
+	cli := &fakeMomentDeleter{event: &openv1alpha1resource.Event{Name: momentTestName}}
+	io, out := momentDeleteTestIO()
+
+	err := deleteMoment(context.Background(), io, cli, mustMomentName(t), true, failIfMomentConfirmed(t))
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Moment: <unnamed> ("+momentTestName+")")
+}
+
+func TestDeleteMomentGetErrorDoesNotDelete(t *testing.T) {
+	cli := &fakeMomentDeleter{getErr: connect.NewError(connect.CodeNotFound, errors.New("missing"))}
+	io, _ := momentDeleteTestIO()
+
+	err := deleteMoment(context.Background(), io, cli, mustMomentName(t), true, failIfMomentConfirmed(t))
+	require.Error(t, err)
+	assert.True(t, utils.IsConnectErrorWithCode(err, connect.CodeNotFound))
+	assert.Nil(t, cli.gotDeleted)
+}
+
+func TestDeleteMomentDeleteErrorPreservesConnectCode(t *testing.T) {
+	cli := &fakeMomentDeleter{deleteErr: connect.NewError(connect.CodePermissionDenied, errors.New("denied"))}
+	io, _ := momentDeleteTestIO()
+
+	err := deleteMoment(context.Background(), io, cli, mustMomentName(t), true, failIfMomentConfirmed(t))
+	require.Error(t, err)
+	assert.True(t, utils.IsConnectErrorWithCode(err, connect.CodePermissionDenied))
+}
+
+func mustMomentName(t *testing.T) *name.Event {
+	t.Helper()
+	eventName, err := name.NewEvent(momentTestName)
+	require.NoError(t, err)
+	return eventName
+}
+
+func momentDeleteTestIO() (*iostreams.IOStreams, *bytes.Buffer) {
+	var out bytes.Buffer
+	return iostreams.Test(nil, &out, &out), &out
+}
+
+func failIfMomentConfirmed(t *testing.T) confirmMomentDelete {
+	t.Helper()
+	return func(string, *iostreams.IOStreams) bool {
+		t.Fatal("confirmation must be skipped")
+		return false
+	}
+}

--- a/pkg/cmd/record/record_test.go
+++ b/pkg/cmd/record/record_test.go
@@ -189,7 +189,7 @@ func TestRecordCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		// Check moment has subcommands
-		expectedMomentSubcommands := []string{"create", "list"}
+		expectedMomentSubcommands := []string{"create", "delete", "download", "list"}
 		for _, expected := range expectedMomentSubcommands {
 			found := false
 			for _, sub := range momentCmd.Commands() {


### PR DESCRIPTION
## Summary

Adds `cocli record moment delete <moment-resource-name/id>` with full resource-name and bare UUID resolution. The command reads and displays the target before deletion, asks for confirmation by default, and supports `--force` for non-interactive use.

The `record moment list` table now shows the moment ID and `DISPLAY NAME`, matching the identifiers exposed by JSON output.

## Validation

- `/Users/juchao/go/bin/go test ./api ./internal/name ./internal/printer/printable ./pkg/cmd/record -count=1`
- `GOCACHE=/tmp/cocli-go-build-cache /Users/juchao/go/bin/go test -race -coverprofile=/tmp/cocli-coverage.txt -covermode=atomic ./...`
- `make lint` (`0 issues`)
- `GOCACHE=/tmp/cocli-go-build-cache /Users/juchao/go/bin/go build -o /tmp/cocli-record-moment-delete ./cmd/cocli`
- Manually deleted moments by bare UUID and full resource name against a live environment, then verified their removal with `record moment list`.

## Operational impact

Deletion only calls the server-side `DeleteEvent` API and does not modify associated tasks. No additional operational monitoring required; this is a client-side CLI command and table-format change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/coCLI/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789654479&installation_model_id=425002&pr_number=193&repository=coscene-io%2FcoCLI&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2FcoCLI%2Fpull%2F193&signature=594eb300cdef33bac4cc6daa5345d8e75358841ef0beacc9918373c10d52959d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->